### PR TITLE
feat: Use `Immutable` everywhere per #23.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -128,9 +128,7 @@ module.exports = (api) => {
         [
             "@babel/preset-env",
             {
-                targets: {
-                    node: "current"
-                },
+                forceAllTransforms: true,
                 useBuiltIns: "entry",
                 shippedProposals: true
             }
@@ -146,12 +144,12 @@ module.exports = (api) => {
     let plugins = [
         "@babel/plugin-proposal-object-rest-spread",
         "react-hot-loader/babel",
-        "lodash"
+        "lodash",
+        configuredMinifyReplace
     ];
 
     switch (api.env()) {
         case "test": {
-            plugins.push(configuredMinifyReplace);
             plugins.push("istanbul");
             break;
         }
@@ -173,26 +171,9 @@ module.exports = (api) => {
             break;
         }
 
-        case "client": {
-            presets = [
-                [
-                    "@babel/preset-env",
-                    {
-                        forceAllTransforms: true,
-                        useBuiltIns: "entry",
-                        shippedProposals: true
-                    }
-                ],
-                [
-                    "@babel/preset-react"
-                ]
-            ];
-            break;
-        }
-
+        case "client":
         case "development":
         default: {
-            plugins.push(configuredMinifyReplace);
             break;
         }
     }

--- a/babel.config.js
+++ b/babel.config.js
@@ -128,7 +128,9 @@ module.exports = (api) => {
         [
             "@babel/preset-env",
             {
-                forceAllTransforms: true,
+                targets: {
+                    node: "current"
+                },
                 useBuiltIns: "entry",
                 shippedProposals: true
             }
@@ -171,7 +173,26 @@ module.exports = (api) => {
             break;
         }
 
-        case "client":
+        case "client": {
+            presets = [
+                [
+                    "@babel/preset-env",
+                    {
+                        forceAllTransforms: true,
+                        useBuiltIns: "entry",
+                        shippedProposals: true
+                    }
+                ],
+                [
+                    "@babel/preset-react",
+                    {
+                        development: api.env() !== "prd"
+                    }
+                ]
+            ];
+            break;
+        }
+
         case "development":
         default: {
             break;

--- a/packages/js/esm.js
+++ b/packages/js/esm.js
@@ -1,10 +1,11 @@
 import Creator from "./lib/creator";
 import Photo from "./lib/photo";
-import Post from "./lib/post";
+import Post, {AbstractPost} from "./lib/post";
 import SizedPhoto from "./lib/sizedPhoto";
 import * as util from "./lib/util";
 
 export {
+    AbstractPost,
     Creator,
     Photo,
     Post,

--- a/packages/js/lib/creator.js
+++ b/packages/js/lib/creator.js
@@ -1,18 +1,18 @@
-class Creator {
-    constructor(id, username, name, sourceUrl) {
-        this.id = id;
-        this.username = username;
-        this.name = name;
-        this.sourceUrl = sourceUrl;
+import {Record} from "immutable";
+
+class Creator extends Record({
+    id: null,
+    username: null,
+    name: null,
+    sourceUrl: null,
+    imageUrl: null
+}) {
+    static fromJS(js) {
+        return new Creator(js);
     }
 
     static fromJSON(json) {
-        return new Creator(
-            json.id,
-            json.username,
-            json.name,
-            json.sourceUrl
-        );
+        return Creator.fromJS(json);
     }
 }
 

--- a/packages/js/lib/post.js
+++ b/packages/js/lib/post.js
@@ -27,12 +27,16 @@ export const PostClassGenerator = otherProperties => class AbstractPost extends 
         return this.constructor.name;
     }
 
-    get dateCreated() {
-        if (this.get("dateCreated")) {
-            return this.get("dateCreated");
+    get date() {
+        return this.datePublished || this.dateCreated;
+    }
+
+    get datePublished() {
+        if (this.get("datePublished")) {
+            return this.get("datePublished");
         }
 
-        return this.datePublished;
+        return this.dateCreated;
     }
 
     static parsePropertiesFromJs(js) {
@@ -68,14 +72,16 @@ export const PostClassGenerator = otherProperties => class AbstractPost extends 
     toJS() {
         return {
             ...super.toJS(),
-            type: this.type
+            type: this.type,
+            datePublished: this.datePublished
         };
     }
 
     toJSON() {
         return {
             ...super.toJSON(),
-            type: this.type
+            type: this.type,
+            datePublished: this.datePublished
         };
     }
 };

--- a/packages/js/lib/post.js
+++ b/packages/js/lib/post.js
@@ -1,53 +1,88 @@
+import {Record} from "immutable";
 import {DateTime} from "luxon";
 import Creator from "./creator";
 import {compositeKeySeparator} from "./util";
 
-class Post {
-    constructor(id, type, source, dateCreated, datePublished, title, body, sourceUrl, creator) {
-        this.id = id;
-        this.type = type || Post.name;
-        this.source = source;
-        this._datePublished = datePublished && DateTime.fromISO(datePublished);
-        this._dateCreated = dateCreated && DateTime.fromISO(dateCreated);
-        this.title = title;
-        this.body = body;
-        this.sourceUrl = sourceUrl;
-        this.creator = creator;
-    }
-
+export const PostClassGenerator = otherProperties => class AbstractPost extends Record({
+    id: null,
+    type: null,
+    source: null,
+    datePublished: null,
+    dateCreated: null,
+    title: null,
+    body: null,
+    sourceUrl: null,
+    creator: null,
+    ...otherProperties
+}) {
     get uid() {
         return `${this.source}${compositeKeySeparator}${this.id}`;
     }
 
-    get datePublished() {
-        return this._datePublished || this._dateCreated;
+    get type() {
+        if (this.get("type")) {
+            return this.get("type");
+        }
+
+        return this.constructor.name;
     }
 
     get dateCreated() {
-        return this._dateCreated || this._datePublished;
+        if (this.get("dateCreated")) {
+            return this.get("dateCreated");
+        }
+
+        return this.datePublished;
+    }
+
+    static parsePropertiesFromJs(js) {
+        return {
+            ...js,
+            dateCreated: js.dateCreated && !(js.dateCreated instanceof DateTime)
+                ? js.dateCreated.valueOf ? DateTime.fromMillis(js.dateCreated.valueOf()) : null
+                : js.dateCreated,
+            datePublished: js.datePublished && !(js.datePublished instanceof DateTime)
+                ? js.datePublished.valueOf ? DateTime.fromMillis(js.datePublished.valueOf()) : null
+                : js.datePublished,
+            creator: js.creator ? Creator.fromJS(js.creator) : null
+        };
+    }
+
+    static fromJS(js) {
+        return new this(this.parsePropertiesFromJs(js));
+    }
+
+    static parsePropertiesFromJson(json) {
+        return {
+            ...json,
+            dateCreated: json.dateCreated ? DateTime.fromISO(json.dateCreated) : null,
+            datePublished: json.datePublished ? DateTime.fromISO(json.datePublished) : null,
+            creator: json.creator ? Creator.fromJSON(json.creator) : null
+        };
     }
 
     static fromJSON(json) {
-        return new Post(
-            json.id,
-            json.type,
-            json.source,
-            json.dateCreated && DateTime.fromISO(json.dateCreated),
-            json.datePublished && DateTime.fromISO(json.datePublished),
-            json.title,
-            json.body,
-            json.sourceUrl,
-            json.creator && Creator.fromJSON(json.creator)
-        );
+        return new this(this.parsePropertiesFromJson(json));
+    }
+
+    toJS() {
+        return {
+            ...super.toJS(),
+            type: this.type
+        };
     }
 
     toJSON() {
         return {
-            ...this,
-            dateCreated: this.dateCreated,
-            datePublished: this.datePublished
+            ...super.toJSON(),
+            type: this.type
         };
     }
+};
+
+export const AbstractPost = PostClassGenerator();
+
+class Post extends PostClassGenerator() {
 }
 
 export default Post;

--- a/packages/js/lib/sizedPhoto.js
+++ b/packages/js/lib/sizedPhoto.js
@@ -1,13 +1,25 @@
-class SizedPhoto {
-    constructor(url, width, height, size) {
-        this.url = url;
-        this.width = width;
-        this.height = height;
-        this.size = size || width && width.toString();
+import {Record} from "immutable";
+
+class SizedPhoto extends Record({
+    url: null,
+    width: null,
+    height: null,
+    size: null,
+}) {
+    get size() {
+        if (this.get("size")) {
+            return this.get("size");
+        }
+
+        return this.width && this.width.toString();
+    }
+
+    static fromJS(js) {
+        return new SizedPhoto(js);
     }
 
     static fromJSON(json) {
-        return new SizedPhoto(json.url, json.width, json.height, json.size);
+        return SizedPhoto.fromJS(json);
     }
 }
 

--- a/packages/js/lib/util/getEntityForType.js
+++ b/packages/js/lib/util/getEntityForType.js
@@ -3,11 +3,13 @@ import Post from "../post";
 
 export default type => {
     switch (type) {
-        case "Photo":
+        case Photo.name:
             return Photo;
 
-        default:
-        case "Post":
+        case Post.name:
             return Post;
+
+        default:
+            throw new Error(`Can't \`getEntityForType\` for \`${type}\``);
     }
 };

--- a/packages/js/lib/util/sortPostsByDate.js
+++ b/packages/js/lib/util/sortPostsByDate.js
@@ -1,7 +1,13 @@
+/**
+ * @function Sort two [Post]{@link Post}s by date, descending.
+ * @param a {Post}
+ * @param b {Post}
+ * @returns {number}
+ */
 export default (a, b) => {
-    if (a.dateCreated.valueOf() > b.dateCreated.valueOf()) {
+    if (a.date.valueOf() > b.date.valueOf()) {
         return -1;
-    } else if (a.dateCreated.valueOf() < b.dateCreated.valueOf()) {
+    } else if (a.date.valueOf() < b.date.valueOf()) {
         return 1;
     } else {
         return 0;

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/randytarampi/me.git"
   },
   "dependencies": {
+    "immutable": "^4.0.0-rc.9",
     "lodash": "^4.17.10",
     "luxon": "^1.3.3"
   },

--- a/packages/js/test/unit/creator.js
+++ b/packages/js/test/unit/creator.js
@@ -2,16 +2,23 @@ import {expect} from "chai";
 import Creator from "../../lib/creator";
 
 describe("Creator", () => {
-    describe(".fromJSON", () => {
+    describe(".fromJS", () => {
         it("should instantiate a Creator object from some plain JS Object", () => {
-            const creatorJSON = {
+            const creatorJs = {
                 id: -1,
                 username: "ʕ•ᴥ•ʔ",
                 name: "ʕ•ᴥ•ʔ",
-                sourceUrl: "woof://woof.woof/woof/woof/woof"
+                sourceUrl: "woof://woof.woof/woof/woof/woof",
+                imageUrl: "meow://meow.meow/meow/meow/meow"
             };
+            const instantiatedCreator = Creator.fromJS(creatorJs);
 
-            expect(new Creator(creatorJSON.id, creatorJSON.username, creatorJSON.name, creatorJSON.sourceUrl)).to.eql(Creator.fromJSON(creatorJSON));
+            expect(instantiatedCreator).to.be.ok;
+            expect(instantiatedCreator.id).to.eql(creatorJs.id);
+            expect(instantiatedCreator.username).to.eql(creatorJs.username);
+            expect(instantiatedCreator.name).to.eql(creatorJs.name);
+            expect(instantiatedCreator.sourceUrl).to.eql(creatorJs.sourceUrl);
+            expect(instantiatedCreator.imageUrl).to.eql(creatorJs.imageUrl);
         });
     });
 });

--- a/packages/js/test/unit/photo.js
+++ b/packages/js/test/unit/photo.js
@@ -72,7 +72,7 @@ describe("Photo", () => {
 
             expect(photoFromJson).to.be.ok;
             expect(photoFromJson.id).to.eql(photoJSON.id);
-            expect(photoFromJson.dateCreated).to.be.instanceof(DateTime);
+            expect(photoFromJson.datePublished).to.be.instanceof(DateTime);
             expect(photoFromJson.sizedPhotos).to.be.instanceof(List);
             expect(photoFromJson.sizedPhotos.size).to.eql(photoJSON.sizedPhotos.length);
             photoFromJson.sizedPhotos.forEach(sizedPhoto => {

--- a/packages/js/test/unit/photo.js
+++ b/packages/js/test/unit/photo.js
@@ -1,4 +1,5 @@
 import {expect} from "chai";
+import {List} from "immutable";
 import {DateTime} from "luxon";
 import Photo from "../../lib/photo";
 import SizedPhoto from "../../lib/sizedPhoto";
@@ -6,16 +7,16 @@ import SizedPhoto from "../../lib/sizedPhoto";
 describe("Photo", () => {
     describe("constructor", () => {
         it("should build a `Photo` object", () => {
-            const photoJSON = {
+            const photoJS = {
                 id: "woof",
                 source: "Woofdy",
-                dateCreated: DateTime.utc().toISO(),
-                datePublished: DateTime.utc().toISO(),
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
                 width: -1,
                 height: -2,
-                sizedPhotos: [
-                    new SizedPhoto("woof://woof.woof/woof/woofto", 640, 480)
-                ],
+                sizedPhotos: List([
+                    SizedPhoto.fromJS({url: "woof://woof.woof/woof/woofto", width: 640, height: 480})
+                ]),
                 title: "Woof woof woof",
                 body: [
                     "ʕ•ᴥ•ʔ",
@@ -30,11 +31,12 @@ describe("Photo", () => {
                     sourceUrl: "woof://woof.woof/woof/woof/woof"
                 }
             };
-            const photo = new Photo(photoJSON.id, photoJSON.type, photoJSON.source, photoJSON.dateCreated, photoJSON.datePublished, photoJSON.width, photoJSON.height, photoJSON.sizedPhotos, photoJSON.sourceUrl, photoJSON.title, photoJSON.body, photoJSON.creator);
+            const photo = new Photo(photoJS);
 
             expect(photo.type).to.eql(Photo.name);
             expect(photo.dateCreated).to.be.an.instanceOf(DateTime);
             expect(photo.datePublished).to.be.an.instanceOf(DateTime);
+            expect(photo.sizedPhotos).to.be.an.instanceOf(List);
         });
     });
 
@@ -44,12 +46,12 @@ describe("Photo", () => {
                 id: "woof",
                 type: "Woof",
                 source: "Woofdy",
-                dateCreated: DateTime.utc().toISO(),
+                dateCreated: null,
                 datePublished: DateTime.utc().toISO(),
                 width: -1,
                 height: -2,
                 sizedPhotos: [
-                    new SizedPhoto("woof://woof.woof/woof/woofto", 640, 480)
+                    {url: "woof://woof.woof/woof/woofto", width: 640, height: 480}
                 ],
                 title: "Woof woof woof",
                 body: [
@@ -66,121 +68,16 @@ describe("Photo", () => {
                 }
             };
 
-            expect(new Photo(photoJSON.id, photoJSON.type, photoJSON.source, photoJSON.dateCreated, photoJSON.datePublished, photoJSON.width, photoJSON.height, photoJSON.sizedPhotos, photoJSON.sourceUrl, photoJSON.title, photoJSON.body, photoJSON.creator)).to.eql(Photo.fromJSON(photoJSON));
-        });
-    });
+            const photoFromJson = Photo.fromJSON(photoJSON);
 
-    //FIXME-RT: This is a weird interface...
-    describe(".sizedPhoto", () => {
-        it("shouldn't have a `.sizedPhoto` getter", () => {
-            const photoJSON = {
-                id: "woof",
-                type: "Woof",
-                source: "Woofdy",
-                dateCreated: null,
-                datePublished: null,
-                width: -1,
-                height: -2,
-                sizedPhotos: [],
-                title: "Woof woof woof",
-                body: [
-                    "ʕ•ᴥ•ʔ",
-                    "ʕ•ᴥ•ʔﾉ゛",
-                    "ʕ◠ᴥ◠ʔ"
-                ],
-                sourceUrl: "woof://woof.woof/woof",
-                creator: {
-                    id: -1,
-                    username: "ʕ•ᴥ•ʔ",
-                    name: "ʕ•ᴥ•ʔ",
-                    sourceUrl: "woof://woof.woof/woof/woof/woof"
-                }
-            };
-            const photo = Photo.fromJSON(photoJSON);
-
-            expect(photo.sizedPhoto).to.eql(undefined);
-        });
-
-        it("should set `SizedPhoto`s properly", () => {
-            const photoJSON = {
-                id: "woof",
-                type: "Woof",
-                source: "Woofdy",
-                dateCreated: null,
-                datePublished: null,
-                width: -1,
-                height: -2,
-                sizedPhotos: [],
-                title: "Woof woof woof",
-                body: [
-                    "ʕ•ᴥ•ʔ",
-                    "ʕ•ᴥ•ʔﾉ゛",
-                    "ʕ◠ᴥ◠ʔ"
-                ],
-                sourceUrl: "woof://woof.woof/woof",
-                creator: {
-                    id: -1,
-                    username: "ʕ•ᴥ•ʔ",
-                    name: "ʕ•ᴥ•ʔ",
-                    sourceUrl: "woof://woof.woof/woof/woof/woof"
-                }
-            };
-            const photo = Photo.fromJSON(photoJSON);
-            const sizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 640, 480);
-
-            photo.sizedPhoto = null;
-            expect(photo.sizedPhotos.length).to.eql(0);
-
-            photo.sizedPhoto = sizedPhoto;
-            expect(photo.sizedPhotos.length).to.eql(1);
-
-            photo.sizedPhoto = sizedPhoto;
-            photo.sizedPhoto = sizedPhoto;
-            expect(photo.sizedPhotos.length).to.eql(3);
-        });
-
-        it("should `scaleHeightToWidth` for `SizedPhoto`s with no `.height` defined", () => {
-            const photoJSON = {
-                id: "woof",
-                type: "Woof",
-                source: "Woofdy",
-                dateCreated: null,
-                datePublished: null,
-                width: -1,
-                height: -2,
-                sizedPhotos: [],
-                title: "Woof woof woof",
-                body: [
-                    "ʕ•ᴥ•ʔ",
-                    "ʕ•ᴥ•ʔﾉ゛",
-                    "ʕ◠ᴥ◠ʔ"
-                ],
-                sourceUrl: "woof://woof.woof/woof",
-                creator: {
-                    id: -1,
-                    username: "ʕ•ᴥ•ʔ",
-                    name: "ʕ•ᴥ•ʔ",
-                    sourceUrl: "woof://woof.woof/woof/woof/woof"
-                }
-            };
-            const photo = Photo.fromJSON(photoJSON);
-
-            const smallSizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 100);
-            const mediumSizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 1000);
-            const largeSizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 10000);
-            const sizedPhotos = [
-                smallSizedPhoto,
-                mediumSizedPhoto,
-                largeSizedPhoto
-            ];
-
-            sizedPhotos.forEach((sizedPhoto) => {
-                photo.sizedPhoto = sizedPhoto;
-            });
-
-            sizedPhotos.forEach((sizedPhoto) => {
-                const selectedPhotoforWidth = photo.getSizedPhoto(sizedPhoto.width);
-                expect(selectedPhotoforWidth.height).to.eql(sizedPhoto.width * (photo.height / photo.width));
+            expect(photoFromJson).to.be.ok;
+            expect(photoFromJson.id).to.eql(photoJSON.id);
+            expect(photoFromJson.dateCreated).to.be.instanceof(DateTime);
+            expect(photoFromJson.sizedPhotos).to.be.instanceof(List);
+            expect(photoFromJson.sizedPhotos.size).to.eql(photoJSON.sizedPhotos.length);
+            photoFromJson.sizedPhotos.forEach(sizedPhoto => {
+                expect(sizedPhoto).to.be.ok;
+                expect(sizedPhoto).to.be.instanceof(SizedPhoto);
             });
         });
     });
@@ -217,6 +114,23 @@ describe("Photo", () => {
         });
 
         it("should return a single member of `.sizedPhotos`, the smallest in size (width), for a given argument", () => {
+            const smallSizedPhoto = SizedPhoto.fromJS({url: "woof://woof.woof/woof/woofto", width: 100, height: 133});
+            const mediumSizedPhoto = SizedPhoto.fromJS({
+                url: "woof://woof.woof/woof/woofto",
+                width: 1000,
+                height: 1333
+            });
+            const largeSizedPhoto = SizedPhoto.fromJS({
+                url: "woof://woof.woof/woof/woofto",
+                width: 10000,
+                height: 13333
+            });
+            const sizedPhotos = [
+                smallSizedPhoto,
+                mediumSizedPhoto,
+                largeSizedPhoto
+            ];
+
             const photoJSON = {
                 id: "woof",
                 type: "Woof",
@@ -225,7 +139,7 @@ describe("Photo", () => {
                 datePublished: null,
                 width: -1,
                 height: -2,
-                sizedPhotos: [],
+                sizedPhotos: sizedPhotos.map(sizedPhoto => sizedPhoto.toJSON()),
                 title: "Woof woof woof",
                 body: [
                     "ʕ•ᴥ•ʔ",
@@ -241,19 +155,6 @@ describe("Photo", () => {
                 }
             };
             const photo = Photo.fromJSON(photoJSON);
-
-            const smallSizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 100, 133);
-            const mediumSizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 1000, 1333);
-            const largeSizedPhoto = new SizedPhoto("woof://woof.woof/woof/woofto", 10000, 13333);
-            const sizedPhotos = [
-                smallSizedPhoto,
-                mediumSizedPhoto,
-                largeSizedPhoto
-            ];
-
-            sizedPhotos.forEach((sizedPhoto) => {
-                photo.sizedPhoto = sizedPhoto;
-            });
 
             sizedPhotos.forEach((sizedPhoto) => {
                 const selectedPhotoforWidth = photo.getSizedPhoto(sizedPhoto.width);

--- a/packages/js/test/unit/post.js
+++ b/packages/js/test/unit/post.js
@@ -94,13 +94,13 @@ describe("Post", () => {
         });
     });
 
-    describe("#dateCreated", function () {
-        it("should set the value of `dateCreated` to be the value of `datePublished` if `dateCreated` is falsy", function () {
+    describe("#datePublished", function () {
+        it("should set the value of `datePublished` to be the value of `dateCreated` if `datePublished` is falsy", function () {
             const postJs = {
                 id: "woof",
                 source: "Woofdy",
-                datePublished: DateTime.utc().toISO(),
-                dateCreated: null,
+                dateCreated: DateTime.utc().toISO(),
+                datePublished: null,
                 title: "Woof woof woof",
                 body: [
                     "ʕ•ᴥ•ʔ",
@@ -123,5 +123,5 @@ describe("Post", () => {
             expect(post.datePublished).to.be.an.instanceOf(DateTime);
             expect(post.datePublished.valueOf()).to.eql(post.dateCreated.valueOf());
         });
-    })
+    });
 });

--- a/packages/js/test/unit/post.js
+++ b/packages/js/test/unit/post.js
@@ -1,16 +1,17 @@
 import {expect} from "chai";
 import {DateTime} from "luxon";
+import Creator from "../../lib/creator";
 import Post from "../../lib/post";
 import {compositeKeySeparator} from "../../lib/util";
 
 describe("Post", () => {
     describe("constructor", () => {
         it("should build a `Post` object", () => {
-            const postJSON = {
+            const postJs = {
                 id: "woof",
                 source: "Woofdy",
-                dateCreated: DateTime.utc().toISO(),
-                datePublished: DateTime.utc().toISO(),
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
                 title: "Woof woof woof",
                 body: [
                     "ʕ•ᴥ•ʔ",
@@ -18,48 +19,19 @@ describe("Post", () => {
                     "ʕ◠ᴥ◠ʔ"
                 ],
                 sourceUrl: "woof://woof.woof/woof",
-                creator: {
+                creator: new Creator({
                     id: -1,
                     username: "ʕ•ᴥ•ʔ",
                     name: "ʕ•ᴥ•ʔ",
                     sourceUrl: "woof://woof.woof/woof/woof/woof"
-                }
+                })
             };
 
-            const post = new Post(postJSON.id, postJSON.type, postJSON.source, postJSON.dateCreated, postJSON.datePublished, postJSON.title, postJSON.body, postJSON.sourceUrl, postJSON.creator);
+            const post = new Post(postJs);
 
             expect(post.type).to.eql(Post.name);
             expect(post.dateCreated).to.be.an.instanceOf(DateTime);
             expect(post.datePublished).to.be.an.instanceOf(DateTime);
-        });
-
-        it("should set the value of `dateCreated` to be the value of `datePublished` if `dateCreated` is falsy", () => {
-            const postJSON = {
-                id: "woof",
-                source: "Woofdy",
-                datePublished: DateTime.utc().toISO(),
-                dateCreated: null,
-                title: "Woof woof woof",
-                body: [
-                    "ʕ•ᴥ•ʔ",
-                    "ʕ•ᴥ•ʔﾉ゛",
-                    "ʕ◠ᴥ◠ʔ"
-                ],
-                sourceUrl: "woof://woof.woof/woof",
-                creator: {
-                    id: -1,
-                    username: "ʕ•ᴥ•ʔ",
-                    name: "ʕ•ᴥ•ʔ",
-                    sourceUrl: "woof://woof.woof/woof/woof/woof"
-                }
-            };
-
-            const post = new Post(postJSON.id, postJSON.type, postJSON.source, postJSON.dateCreated, postJSON.datePublished, postJSON.title, postJSON.body, postJSON.sourceUrl, postJSON.creator);
-
-            expect(post.type).to.eql(Post.name);
-            expect(post.dateCreated).to.be.an.instanceOf(DateTime);
-            expect(post.datePublished).to.be.an.instanceOf(DateTime);
-            expect(post.datePublished.valueOf()).to.eql(post.dateCreated.valueOf());
         });
     });
 
@@ -86,7 +58,11 @@ describe("Post", () => {
                 }
             };
 
-            expect(new Post(postJSON.id, postJSON.type, postJSON.source, postJSON.dateCreated, postJSON.datePublished, postJSON.title, postJSON.body, postJSON.sourceUrl, postJSON.creator)).to.eql(Post.fromJSON(postJSON));
+            const postFromJson = Post.fromJSON(postJSON);
+
+            expect(postFromJson).to.be.ok;
+            expect(postFromJson.id).to.eql(postJSON.id);
+            expect(postFromJson.dateCreated).to.be.instanceof(DateTime);
         });
     });
 
@@ -117,4 +93,35 @@ describe("Post", () => {
             expect(post.uid).to.eql(`${postJSON.source}${compositeKeySeparator}${postJSON.id}`);
         });
     });
+
+    describe("#dateCreated", function () {
+        it("should set the value of `dateCreated` to be the value of `datePublished` if `dateCreated` is falsy", function () {
+            const postJs = {
+                id: "woof",
+                source: "Woofdy",
+                datePublished: DateTime.utc().toISO(),
+                dateCreated: null,
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: new Creator({
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    sourceUrl: "woof://woof.woof/woof/woof/woof"
+                })
+            };
+
+            const post = Post.fromJSON(postJs);
+
+            expect(post.type).to.eql(Post.name);
+            expect(post.dateCreated).to.be.an.instanceOf(DateTime);
+            expect(post.datePublished).to.be.an.instanceOf(DateTime);
+            expect(post.datePublished.valueOf()).to.eql(post.dateCreated.valueOf());
+        });
+    })
 });

--- a/packages/js/test/unit/sizedPhoto.js
+++ b/packages/js/test/unit/sizedPhoto.js
@@ -2,15 +2,46 @@ import {expect} from "chai";
 import SizedPhoto from "../../lib/sizedPhoto";
 
 describe("SizedPhoto", () => {
-    describe(".fromJSON", () => {
+    describe(".fromJS", () => {
         it("should instantiate a SizedPhoto object from some plain JS Object", () => {
-            const sizedPhotoJSON = {
+            const sizedPhotoJs = {
                 width: -1,
                 height: -2,
                 url: "woof://woof.woof/woof/woof/woof"
             };
+            const instantiatedSizedPhoto = SizedPhoto.fromJS(sizedPhotoJs);
 
-            expect(new SizedPhoto(sizedPhotoJSON.url, sizedPhotoJSON.width, sizedPhotoJSON.height, sizedPhotoJSON.size)).to.eql(SizedPhoto.fromJSON(sizedPhotoJSON));
+            expect(instantiatedSizedPhoto).to.be.ok;
+            expect(instantiatedSizedPhoto.width).to.eql(sizedPhotoJs.width);
+            expect(instantiatedSizedPhoto.height).to.eql(sizedPhotoJs.height);
+            expect(instantiatedSizedPhoto.url).to.eql(sizedPhotoJs.url);
+        });
+    });
+
+    describe(".size", () => {
+        it("gets the set `.size`", () => {
+            const sizedPhotoJs = {
+                width: -1,
+                height: -2,
+                url: "woof://woof.woof/woof/woof/woof",
+                size: "meow"
+            };
+            const instantiatedSizedPhoto = SizedPhoto.fromJS(sizedPhotoJs);
+
+            expect(instantiatedSizedPhoto).to.be.ok;
+            expect(instantiatedSizedPhoto.size).to.eql(sizedPhotoJs.size);
+        });
+
+        it("defers to the `.width` when there is no `.size`", () => {
+            const sizedPhotoJs = {
+                width: -1,
+                height: -2,
+                url: "woof://woof.woof/woof/woof/woof"
+            };
+            const instantiatedSizedPhoto = SizedPhoto.fromJS(sizedPhotoJs);
+
+            expect(instantiatedSizedPhoto).to.be.ok;
+            expect(instantiatedSizedPhoto.size).to.eql(sizedPhotoJs.width.toString());
         });
     });
 });

--- a/packages/jsx/esm.js
+++ b/packages/jsx/esm.js
@@ -4,7 +4,7 @@ import Emoji from "./lib/components/emoji";
 import Link from "./lib/components/link";
 import LoadingSpinner from "./lib/components/loadingSpinner";
 import RowBlock from "./lib/components/rowBlock";
-import Error from "./lib/containers/error";
+import ErrorWrapper from "./lib/containers/errorWrapper";
 
 import Posts from "./lib/containers/posts";
 
@@ -24,7 +24,7 @@ export {
     RowBlock,
 
     Posts,
-    Error,
+    ErrorWrapper,
 
     reducers,
     selectors,

--- a/packages/jsx/lib/actions/fetchPosts.js
+++ b/packages/jsx/lib/actions/fetchPosts.js
@@ -1,4 +1,3 @@
-import {push} from "react-router-redux";
 import {createAction} from "redux-actions";
 import fetchPosts from "../api/fetchPosts";
 import {isUrlStateLoading} from "../data/api";
@@ -66,7 +65,6 @@ export default fetchUrl => (dispatch, getState) => {
 
             if (!postsResponse || !postsResponse.posts || !postsResponse.posts.length) {
                 dispatch(setError(undefined, "ENOPOSTS"));
-                dispatch(push("./error"));
             }
         })
         .catch(error => {
@@ -75,7 +73,6 @@ export default fetchUrl => (dispatch, getState) => {
                 error
             }));
             dispatch(setError(error, "EFETCH"));
-            dispatch(push("./error"));
 
             throw error;
         });

--- a/packages/jsx/lib/actions/fetchPosts.js
+++ b/packages/jsx/lib/actions/fetchPosts.js
@@ -26,7 +26,7 @@ export default fetchUrl => (dispatch, getState) => {
     }
 
     const oldestLoadedPost = selectors.getOldestPost(state);
-    const oldestLoadedPostDate = oldestLoadedPost && oldestLoadedPost.dateCreated;
+    const oldestLoadedPostDate = oldestLoadedPost && oldestLoadedPost.datePublished;
     const oldestPostAvailableDate = urlState && urlState.get("oldest");
 
     if (oldestPostAvailableDate && oldestLoadedPostDate && oldestLoadedPostDate.diff(oldestPostAvailableDate) <= 0) {
@@ -43,7 +43,7 @@ export default fetchUrl => (dispatch, getState) => {
         ...(
             oldestLoadedPostDate
                 ? {
-                    orderBy: "dateCreated",
+                    orderBy: "datePublished",
                     orderOperator: "lt",
                     orderComparator: oldestLoadedPostDate && oldestLoadedPostDate.toISO(),
                     orderComparatorType: "String",

--- a/packages/jsx/lib/clientReduxRoot.jsx
+++ b/packages/jsx/lib/clientReduxRoot.jsx
@@ -4,11 +4,14 @@ import {metrics} from "react-metrics";
 import {Provider} from "react-redux";
 import {renderRoutes} from "react-router-config";
 import {ConnectedRouter} from "react-router-redux";
+import ErrorWrapper from "./containers/errorWrapper";
 import metricsConfig from "./metrics/config";
 
 const ClientReduxRoot = ({store, history, routes, ...props}) => <Provider store={store}>
     <ConnectedRouter history={history}>
-        {renderRoutes(routes, props)}
+        <ErrorWrapper {...props}>
+            {renderRoutes(routes, props)}
+        </ErrorWrapper>
     </ConnectedRouter>
 </Provider>;
 

--- a/packages/jsx/lib/components/errorWrapper.jsx
+++ b/packages/jsx/lib/components/errorWrapper.jsx
@@ -1,0 +1,23 @@
+import PropTypes from "prop-types";
+import React, {Fragment} from "react";
+import Error from "./error";
+
+const ErrorWrapper = props => {
+    return <Fragment>
+        {
+            props.hasError
+                ? <Error {...props} />
+                : props.children
+        }
+    </Fragment>;
+};
+
+ErrorWrapper.propTypes = {
+    hasError: PropTypes.bool
+};
+
+ErrorWrapper.defaultProps = {
+    hasError: false
+};
+
+export default ErrorWrapper;

--- a/packages/jsx/lib/components/posts.jsx
+++ b/packages/jsx/lib/components/posts.jsx
@@ -11,7 +11,7 @@ export class PostsComponent extends Component {
     render() {
         return <Infinite
             useWindowAsScrollContainer={true}
-            elementHeight={this.props.posts ? this.props.posts.toJS().map(computePostHeight(this.props.containerWidth)) : [500]}
+            elementHeight={this.props.posts ? this.props.posts.toArray().map(computePostHeight(this.props.containerWidth)) : [500]}
             infiniteLoadBeginEdgeOffset={Infinite.containerHeightScaleFactor(2).amount}
             onInfiniteLoad={this.props.fetchPosts}
             isInfiniteLoading={this.props.isLoading}
@@ -19,7 +19,7 @@ export class PostsComponent extends Component {
         >
             {
                 this.props.posts
-                    ? this.props.posts.toJS().map(post => {
+                    ? this.props.posts.toArray().map(post => {
                         const Constructor = getComponentForType(post.type);
                         return <Constructor key={post.uid} post={post}/>;
                     })

--- a/packages/jsx/lib/containers/errorWrapper.jsx
+++ b/packages/jsx/lib/containers/errorWrapper.jsx
@@ -2,12 +2,14 @@ import PropTypes from "prop-types";
 import {connect} from "react-redux";
 import {push} from "react-router-redux";
 import clearError from "../actions/clearError";
-import Error from "../components/error";
+import ErrorWrapper from "../components/errorWrapper";
 import selectors from "../data/selectors";
 
-const ConnectedError = connect(
+const ConnectedErrorWrapper = connect(
     state => {
         return {
+            location: selectors.getLocation(state),
+            hasError: selectors.hasError(state),
             error: selectors.getError(state),
             errorCode: selectors.getErrorCode(state),
             errorMessage: selectors.getErrorMessage(state)
@@ -23,17 +25,16 @@ const ConnectedError = connect(
             }, ownProps.redirectionTimeout * 1000)
         };
     }
-)(Error);
+)(ErrorWrapper);
 
-ConnectedError.propTypes = {
-    location: PropTypes.object.isRequired,
+ConnectedErrorWrapper.propTypes = {
     redirectionLocation: PropTypes.string.isRequired,
     redirectionTimeout: PropTypes.number
 };
 
-ConnectedError.defaultProps = {
+ConnectedErrorWrapper.defaultProps = {
     redirectionLocation: "/",
     redirectionTimeout: 10
 };
 
-export default ConnectedError;
+export default ConnectedErrorWrapper;

--- a/packages/jsx/lib/data/api.js
+++ b/packages/jsx/lib/data/api.js
@@ -61,7 +61,7 @@ export const getApiStateForUrl = (state, url) => getApiState(state).get(url) || 
 // NOTE-RT: Utility functions
 export const isUrlStateLoading = urlState => urlState ? !!urlState.get("isLoading") : null;
 export const getErrorForUrlState = urlState => urlState ? urlState.get("error") : null;
-const getApiStateForUrlFromGlobalState = (state, url) => getApiStateForUrl(state.api, url);
+const getApiStateForUrlFromGlobalState = (state, url) => getApiStateForUrl(state.get("api"), url);
 
 // NOTE-RT: Private selectors for individual containers
 export const createIsLoadingUrlSelector = () => createSelector(

--- a/packages/jsx/lib/data/error.js
+++ b/packages/jsx/lib/data/error.js
@@ -20,7 +20,7 @@ export default (state = Map(), action) => {
     }
 };
 
-export const hasError = state => !!getErrorState(state);
+export const hasError = state => !!getError(state) || !!getErrorMessage(state) || !!getErrorCode(state);
 export const getErrorState = state => state;
 export const getError = state => getErrorState(state).get("error");
 export const getErrorMessage = state => getErrorState(state).get("errorMessage");

--- a/packages/jsx/lib/data/reducers.js
+++ b/packages/jsx/lib/data/reducers.js
@@ -1,8 +1,8 @@
-import {routerReducer as routing} from "react-router-redux";
-import {combineReducers} from "redux";
+import {combineReducers} from "redux-immutable";
 import api from "./api";
 import error from "./error";
 import posts from "./posts";
+import routing from "./routing";
 
 export default combineReducers({
     api,

--- a/packages/jsx/lib/data/routing.js
+++ b/packages/jsx/lib/data/routing.js
@@ -1,0 +1,21 @@
+import {Map} from "immutable";
+import {LOCATION_CHANGE} from "react-router-redux";
+
+const initialState = Map({
+    location: null,
+    action: null
+});
+
+// NOTE-RT: Lifted directly from https://github.com/gajus/redux-immutable/pull/71/files#diff-04c6e90faac2675aa89e2176d2eec7d8R105
+export default (state = initialState, {type, payload = {}} = {}) => {
+    if (type === LOCATION_CHANGE) {
+        const location = payload.location || payload;
+        const action = payload.action;
+
+        return state
+            .set("location", location)
+            .set("action", action);
+    }
+
+    return state;
+};

--- a/packages/jsx/lib/data/routing.js
+++ b/packages/jsx/lib/data/routing.js
@@ -19,3 +19,5 @@ export default (state = initialState, {type, payload = {}} = {}) => {
 
     return state;
 };
+
+export const getLocation = state => state.get("location");

--- a/packages/jsx/lib/data/selectors.js
+++ b/packages/jsx/lib/data/selectors.js
@@ -12,21 +12,21 @@ import {
 } from "./posts";
 
 export default {
-    hasError: state => hasError(state.error),
-    getError: state => getError(state.error),
-    getErrorCode: state => getErrorCode(state.error),
-    getErrorMessage: state => getErrorMessage(state.error),
-    getErrorState: state => getErrorState(state.error),
+    hasError: state => hasError(state.get("error")),
+    getError: state => getError(state.get("error")),
+    getErrorCode: state => getErrorCode(state.get("error")),
+    getErrorMessage: state => getErrorMessage(state.get("error")),
+    getErrorState: state => getErrorState(state.get("error")),
 
-    getPosts: state => getPosts(state.posts),
-    getPhotoPosts: state => getPhotoPosts(state.posts),
-    getWordPosts: state => getWordPosts(state.posts),
-    getPostsSortedByDate: state => getPostsSortedByDate(state.posts),
-    getPhotoPostsSortedByDate: state => getPhotoPostsSortedByDate(state.posts),
-    getWordPostsSortedByDate: state => getWordPostsSortedByDate(state.posts),
-    getOldestPost: state => getOldestPost(state.posts),
-    getNewestPost: state => getNewestPost(state.posts),
+    getPosts: state => getPosts(state.get("posts")),
+    getPhotoPosts: state => getPhotoPosts(state.get("posts")),
+    getWordPosts: state => getWordPosts(state.get("posts")),
+    getPostsSortedByDate: state => getPostsSortedByDate(state.get("posts")),
+    getPhotoPostsSortedByDate: state => getPhotoPostsSortedByDate(state.get("posts")),
+    getWordPostsSortedByDate: state => getWordPostsSortedByDate(state.get("posts")),
+    getOldestPost: state => getOldestPost(state.get("posts")),
+    getNewestPost: state => getNewestPost(state.get("posts")),
 
-    getApiState: state => getApiState(state.api),
-    getApiStateForUrl: (state, url) => getApiStateForUrl(state.api, url)
+    getApiState: state => getApiState(state.get("api")),
+    getApiStateForUrl: (state, url) => getApiStateForUrl(state.get("api"), url)
 };

--- a/packages/jsx/lib/data/selectors.js
+++ b/packages/jsx/lib/data/selectors.js
@@ -10,6 +10,7 @@ import {
     getWordPosts,
     getWordPostsSortedByDate
 } from "./posts";
+import {getLocation} from "./routing";
 
 export default {
     hasError: state => hasError(state.get("error")),
@@ -28,5 +29,7 @@ export default {
     getNewestPost: state => getNewestPost(state.get("posts")),
 
     getApiState: state => getApiState(state.get("api")),
-    getApiStateForUrl: (state, url) => getApiStateForUrl(state.get("api"), url)
+    getApiStateForUrl: (state, url) => getApiStateForUrl(state.get("api"), url),
+
+    getLocation: state => getLocation(state.get("routing"))
 };

--- a/packages/jsx/lib/serverReduxRoot.jsx
+++ b/packages/jsx/lib/serverReduxRoot.jsx
@@ -3,10 +3,13 @@ import React from "react";
 import {Provider} from "react-redux";
 import {renderRoutes} from "react-router-config";
 import {StaticRouter} from "react-router-dom";
+import ErrorWrapper from "./containers/errorWrapper";
 
 const ServerReduxRoot = ({store, context, routes, ...props}) => <Provider store={store}>
     <StaticRouter context={context}>
-        {renderRoutes(routes, props)}
+        <ErrorWrapper {...props}>
+            {renderRoutes(routes, props)}
+        </ErrorWrapper>
     </StaticRouter>
 </Provider>;
 

--- a/packages/jsx/lib/store/configureStore.js
+++ b/packages/jsx/lib/store/configureStore.js
@@ -1,3 +1,4 @@
+import {Map} from "immutable";
 import {routerMiddleware} from "react-router-redux";
 import {applyMiddleware, createStore} from "redux";
 import {composeWithDevTools} from "redux-devtools-extension";
@@ -6,7 +7,7 @@ import metrics from "../middleware/metrics";
 import raven from "../middleware/raven";
 import router from "../middleware/router";
 
-const configureStore = (initialState = {}, history, reducers) => {
+const configureStore = (initialState = Map(), history, reducers) => {
     const middlewares = [thunk, metrics, routerMiddleware(history), router];
 
     if (typeof window !== "undefined" && window.SENTRY_DSN) {

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -47,6 +47,7 @@
     "react-router-redux": "^5.0.0-alpha.9",
     "redux-actions": "^2.4.0",
     "redux-devtools-extension": "^2.13.5",
+    "redux-immutable": "^4.0.0",
     "redux-raven-middleware": "^1.2.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1"

--- a/packages/jsx/test/unit/actions/fetchPosts.js
+++ b/packages/jsx/test/unit/actions/fetchPosts.js
@@ -188,7 +188,7 @@ describe("fetchPosts", function () {
             const stubSearchParams = {
                 perPage: FETCHING_POSTS_PER_PAGE,
                 orderComparator: stubLoadedPost.dateCreated.toISO(),
-                orderBy: "dateCreated",
+                orderBy: "datePublished",
                 orderComparatorType: "String",
                 orderOperator: "lt"
             };

--- a/packages/jsx/test/unit/actions/fetchPosts.js
+++ b/packages/jsx/test/unit/actions/fetchPosts.js
@@ -3,7 +3,6 @@ import {expect} from "chai";
 import {Map, Set} from "immutable";
 import {DateTime} from "luxon";
 import proxyquire from "proxyquire";
-import {CALL_HISTORY_METHOD} from "react-router-redux";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import {
@@ -24,12 +23,12 @@ describe("fetchPosts", function () {
     beforeEach(function () {
         stubMiddleware = [thunk];
         mockStore = configureStore(stubMiddleware);
-        stubInitialState = {
+        stubInitialState = Map({
             api: Map(),
             posts: Map({
                 posts: Set()
             })
-        };
+        });
         stubStore = mockStore(stubInitialState);
     });
 
@@ -49,14 +48,14 @@ describe("fetchPosts", function () {
                 }
             });
 
-            stubInitialState = {
+            stubInitialState = Map({
                 api: Map({
                     [stubFetchUrl]: Map({
                         isLoading: true
                     })
                 }),
                 posts: Map({posts: Set()}),
-            };
+            });
             stubStore = mockStore(stubInitialState);
 
             return stubStore.dispatch(proxyquiredFetchPosts.default(stubFetchUrl))
@@ -93,7 +92,7 @@ describe("fetchPosts", function () {
                 }
             });
 
-            stubInitialState = {
+            stubInitialState = Map({
                 api: Map({
                     [stubFetchUrl]: Map({
                         isLoading: false,
@@ -103,7 +102,7 @@ describe("fetchPosts", function () {
                     })
                 }),
                 posts: Map({posts: Set([stubLoadedPost])}),
-            };
+            });
             stubStore = mockStore(stubInitialState);
 
             return stubStore.dispatch(proxyquiredFetchPosts.default(stubFetchUrl))
@@ -117,7 +116,7 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_CANCELLED,
                             payload: {
                                 fetchUrl: stubFetchUrl,
-                                oldestPostAvailableDate: stubInitialState.api.get(stubFetchUrl).get("oldest"),
+                                oldestPostAvailableDate: stubInitialState.getIn(["api", stubFetchUrl, "oldest"]),
                                 oldestLoadedPostDate: stubLoadedPost.dateCreated
                             }
                         }
@@ -207,7 +206,7 @@ describe("fetchPosts", function () {
                 }
             });
 
-            stubInitialState = {
+            stubInitialState = Map({
                 api: Map({
                     [stubFetchUrl]: Map({
                         oldest: DateTime.utc(1991, 11, 14),
@@ -217,7 +216,7 @@ describe("fetchPosts", function () {
                 posts: Map({
                     posts: Set([stubLoadedPost])
                 })
-            };
+            });
             stubStore = mockStore(stubInitialState);
 
             return stubStore.dispatch(proxyquiredFetchPosts.default(stubFetchUrl))
@@ -268,10 +267,7 @@ describe("fetchPosts", function () {
             return stubStore.dispatch(proxyquiredFetchPosts.default(stubFetchUrl))
                 .then(() => {
                     const actions = stubStore.getActions();
-
-                    expect(actions).to.be.ok;
-                    expect(actions).to.have.length(4);
-                    expect(actions).to.eql([
+                    const expectedActions = [
                         {
                             type: FETCHING_POSTS,
                             payload: {
@@ -293,17 +289,12 @@ describe("fetchPosts", function () {
                                 errorCode: "ENOPOSTS",
                                 errorMessage: undefined
                             }
-                        },
-                        {
-                            type: CALL_HISTORY_METHOD,
-                            payload: {
-                                args: [
-                                    "./error"
-                                ],
-                                method: "push"
-                            }
                         }
-                    ]);
+                    ];
+
+                    expect(actions).to.be.ok;
+                    expect(actions).to.have.length(expectedActions.length);
+                    expect(actions).to.eql(expectedActions);
                 });
         });
 
@@ -326,10 +317,7 @@ describe("fetchPosts", function () {
                     expect(error).to.eql(stubPostsResponse);
 
                     const actions = stubStore.getActions();
-
-                    expect(actions).to.be.ok;
-                    expect(actions).to.have.length(4);
-                    expect(actions).to.eql([
+                    const expectedActions = [
                         {
                             type: FETCHING_POSTS,
                             payload: {
@@ -351,17 +339,12 @@ describe("fetchPosts", function () {
                                 errorCode: "EFETCH",
                                 errorMessage: undefined
                             }
-                        },
-                        {
-                            type: CALL_HISTORY_METHOD,
-                            payload: {
-                                args: [
-                                    "./error"
-                                ],
-                                method: "push"
-                            }
                         }
-                    ]);
+                    ];
+
+                    expect(actions).to.be.ok;
+                    expect(actions).to.have.length(expectedActions.length);
+                    expect(actions).to.eql(expectedActions);
                 });
         });
     });

--- a/packages/jsx/test/unit/api/fetchPosts.js
+++ b/packages/jsx/test/unit/api/fetchPosts.js
@@ -1,4 +1,4 @@
-import {Photo, Post} from "@randy.tarampi/js";
+import {Photo, Post, util} from "@randy.tarampi/js";
 import {expect} from "chai";
 import {DateTime} from "luxon";
 import proxyquire from "proxyquire";
@@ -17,11 +17,11 @@ describe("fetchPosts", function () {
             dateCreated: DateTime.utc().toISO(),
             datePublished: DateTime.utc().toISO()
         });
-        const stubPosts = [stubPost, stubPhoto];
+        const stubPosts = [stubPost, stubPhoto].map(post => post.toJSON());
         const stubPostsResponse = {
             json: () => {
                 return Promise.resolve({
-                    posts: stubPosts.map(post => post.toJSON()),
+                    posts: stubPosts,
                     total: stubPosts.length,
                     oldest: stubPost.dateCreated.toISO(),
                     newest: stubPhoto.dateCreated.toISO()
@@ -63,7 +63,7 @@ describe("fetchPosts", function () {
             .then(postsResponse => {
                 expect(postsResponse).to.be.ok;
                 expect(postsResponse).to.eql({
-                    posts: stubPosts,
+                    posts: stubPosts.map(post => util.getEntityForType(post.type).fromJS(post)),
                     total: stubPosts.length,
                     oldest: stubPost.dateCreated.toISO(),
                     newest: stubPhoto.dateCreated.toISO()

--- a/packages/posts/db/models/post.js
+++ b/packages/posts/db/models/post.js
@@ -13,7 +13,7 @@ const postModelInstanceToEntity = postModelInstance => postModelInstance && post
  */
 export const createPost = async post => {
     logger.debug(`[Post.createPost] persisting post (${post.uid})`);
-    const postModelInstance = await Post.create(post, {overwrite: true});
+    const postModelInstance = await Post.create(post.toJS(), {overwrite: true});
     logger.debug(`[Post.createPost] persisted post (${JSON.stringify(postModelInstance && postModelInstance.uid)})`);
     return postModelInstanceToEntity(postModelInstance);
 };
@@ -41,7 +41,7 @@ export const getPost = async ({_options, _filter, _query}) => {
  */
 export const createPosts = async posts => {
     logger.debug(`[Post.createPosts] persisting posts (${JSON.stringify(posts.map(post => post.uid))})`);
-    await Post.batchPut(posts, {overwrite: true});
+    await Post.batchPut(posts.map(post => post.toJS()), {overwrite: true});
     const postModelInstances = await Post.batchGet(posts.map(post => post.uid)); // NOTE-RT: Ugh. This is gross af. According to the docs, `batchPut`should return some Dynamoose model instances, but if you look at their tests and source they just return a statement of success and what wasn't processed
     logger.debug(`[Post.createPosts] persisted posts (${JSON.stringify(postModelInstances.map(postModelInstance => postModelInstance.uid))})`);
     return postModelInstances.map(postModelInstanceToEntity);

--- a/packages/posts/db/schema/post.js
+++ b/packages/posts/db/schema/post.js
@@ -20,13 +20,13 @@ const post = new Schema({
         index: [
             {
                 global: true,
-                name: "type-dateCreated-index",
-                rangeKey: "dateCreated"
+                name: "type-datePublished-index",
+                rangeKey: "datePublished"
             },
             {
                 global: true,
-                name: "type-datePublished-index",
-                rangeKey: "datePublished"
+                name: "type-dateCreated-index",
+                rangeKey: "dateCreated"
             },
             {
                 global: true,
@@ -41,18 +41,19 @@ const post = new Schema({
         index: [
             {
                 global: true,
-                name: "source-dateCreated-index",
-                rangeKey: "dateCreated"
+                name: "source-datePublished-index",
+                rangeKey: "datePublished"
             },
             {
                 global: true,
-                name: "source-datePublished-index",
-                rangeKey: "datePublished"
+                name: "source-dateCreated-index",
+                rangeKey: "dateCreated"
             }
         ]
     },
     datePublished: {
         type: Date,
+        required: true,
         get: date => date ? date.toISOString() : date
     },
     dateCreated: {

--- a/packages/posts/photos/flickr/photoSource.js
+++ b/packages/posts/photos/flickr/photoSource.js
@@ -40,7 +40,7 @@ class FlickrSource extends PhotoSource {
         return Photo.fromJS({
             id: json.id,
             source: this.type,
-            dateCreated: DateTime.fromMillis(parseInt(json.datetaken, 10) * 1000),
+            dateCreated: json.datetaken && DateTime.fromSQL(json.datetaken) || null,
             datePublished: DateTime.fromMillis(parseInt(json.dateupload, 10) * 1000),
             width: json.width_o,
             height: json.height_o,

--- a/packages/posts/photos/flickr/photoSource.js
+++ b/packages/posts/photos/flickr/photoSource.js
@@ -1,4 +1,4 @@
-import {Creator, Photo, SizedPhoto} from "@randy.tarampi/js";
+import {Photo} from "@randy.tarampi/js";
 import Flickr from "flickr-sdk";
 import _ from "lodash";
 import {DateTime} from "luxon";
@@ -37,34 +37,32 @@ class FlickrSource extends PhotoSource {
     }
 
     jsonToPost(json) {
-        return new Photo(
-            json.id,
-            null,
-            this.type,
-            DateTime.fromMillis(parseInt(json.datetaken, 10) * 1000),
-            DateTime.fromMillis(parseInt(json.dateupload, 10) * 1000),
-            json.width_o,
-            json.height_o,
-            [
-                new SizedPhoto(json.url_o, json.width_o, json.height_o, "raw"),
-                new SizedPhoto(json.url_o, json.width_o, json.height_o, "full"),
-                new SizedPhoto(json.url_k, json.width_k, json.height_k),
-                new SizedPhoto(json.url_h, json.width_h, json.height_h),
-                new SizedPhoto(json.url_c, json.width_c, json.height_c),
-                new SizedPhoto(json.url_z, json.width_z, json.height_z),
-                new SizedPhoto(json.url_m, json.width_m, json.height_m),
-                new SizedPhoto(json.url_n, json.width_n, json.height_n)
+        return Photo.fromJS({
+            id: json.id,
+            source: this.type,
+            dateCreated: DateTime.fromMillis(parseInt(json.datetaken, 10) * 1000),
+            datePublished: DateTime.fromMillis(parseInt(json.dateupload, 10) * 1000),
+            width: json.width_o,
+            height: json.height_o,
+            sizedPhotos: [
+                {url: json.url_o, width: json.width_o, height: json.height_o, size: "raw"},
+                {url: json.url_o, width: json.width_o, height: json.height_o, size: "full"},
+                {url: json.url_k, width: json.width_k, height: json.height_k},
+                {url: json.url_h, width: json.width_h, height: json.height_h},
+                {url: json.url_c, width: json.width_c, height: json.height_c},
+                {url: json.url_z, width: json.width_z, height: json.height_z},
+                {url: json.url_m, width: json.width_m, height: json.height_m},
+                {url: json.url_n, width: json.width_n, height: json.height_n}
             ],
-            `https://www.flickr.com/${json.pathalias}/${json.id}`,
-            json.title,
-            json.description && json.description._content,
-            new Creator(
-                json.owner,
-                json.ownername,
-                null,
-                `https://www.flickr.com/${json.ownername}`
-            )
-        );
+            sourceUrl: `https://www.flickr.com/${json.pathalias}/${json.id}`,
+            title: json.title,
+            body: json.description && json.description._content,
+            creator: {
+                id: json.owner,
+                username: json.ownername,
+                sourceUrl: `https://www.flickr.com/${json.ownername}`
+            }
+        });
     }
 }
 

--- a/packages/posts/photos/instagram/photoSource.js
+++ b/packages/posts/photos/instagram/photoSource.js
@@ -1,4 +1,4 @@
-import {Creator, Photo, SizedPhoto} from "@randy.tarampi/js";
+import {Photo, SizedPhoto} from "@randy.tarampi/js";
 import Instagram from "instagram-api";
 import fetch from "isomorphic-fetch";
 import _ from "lodash";
@@ -60,30 +60,28 @@ class InstagramSource extends PhotoSource {
     jsonToPost(photoJson) {
         const sizedPhotos = Object.keys(photoJson.images).map(key => {
             const image = photoJson.images[key];
-            return new SizedPhoto(image.url, image.width, image.height, key);
+            return SizedPhoto.fromJSON({...image, size: key});
         });
 
         const biggestOfficialPhoto = _.last(_.sortBy(sizedPhotos, ["width"]));
 
-        return new Photo(
-            photoJson.id,
-            null,
-            this.type,
-            DateTime.fromMillis(parseInt(photoJson.created_time, 10) * 1000),
-            null,
-            biggestOfficialPhoto.width,
-            biggestOfficialPhoto.height,
+        return Photo.fromJS({
+            id: photoJson.id,
+            source: this.type,
+            datePublished: DateTime.fromMillis(parseInt(photoJson.created_time, 10) * 1000),
+            width: biggestOfficialPhoto.width,
+            height: biggestOfficialPhoto.height,
             sizedPhotos,
-            photoJson.link,
-            photoJson.location && photoJson.location.name,
-            photoJson.caption && photoJson.caption.text,
-            new Creator(
-                photoJson.user.username,
-                photoJson.user.username,
-                photoJson.user.full_name,
-                `https://www.instagram.com/${photoJson.user.username}`
-            )
-        );
+            sourceUrl: photoJson.link,
+            title: photoJson.location && photoJson.location.name,
+            body: photoJson.caption && photoJson.caption.text,
+            creator: {
+                id: photoJson.user.username,
+                username: photoJson.user.username,
+                name: photoJson.user.full_name,
+                sourceUrl: `https://www.instagram.com/${photoJson.user.username}`
+            }
+        });
     }
 }
 

--- a/packages/posts/photos/unsplash/photoSource.js
+++ b/packages/posts/photos/unsplash/photoSource.js
@@ -1,6 +1,5 @@
-import {Creator, Photo, SizedPhoto} from "@randy.tarampi/js";
+import {Photo} from "@randy.tarampi/js";
 import "isomorphic-fetch";
-import {DateTime} from "luxon";
 import Unsplash, {toJson} from "unsplash-js";
 import PhotoSource from "../photoSource";
 
@@ -29,31 +28,27 @@ class UnsplashSource extends PhotoSource {
     }
 
     jsonToPost(json) {
-        return new Photo(
-            json.id,
-            null,
-            this.type,
-            DateTime.fromISO(json.created_at),
-            null,
-            json.width,
-            json.height,
-            [
-                new SizedPhoto(json.urls.raw, json.width, json.height, "raw"),
-                new SizedPhoto(json.urls.full, json.width, json.height, "full"),
-                new SizedPhoto(json.urls.regular, json.width, json.height, "regular"),
-                new SizedPhoto(json.urls.small, json.width, json.height, "small")
+        return Photo.fromJSON({
+            id: json.id,
+            source: this.type,
+            datePublished: json.created_at,
+            width: json.width,
+            height: json.height,
+            sizedPhotos: [
+                {url: json.urls.raw, width: json.width, height: json.height, size: "raw"},
+                {url: json.urls.full, width: json.width, height: json.height, size: "full"},
+                {url: json.urls.regular, width: json.width, height: json.height, size: "regular"},
+                {url: json.urls.small, width: json.width, height: json.height, size: "small"}
             ],
-            json.links.html,
-            null,
-            null,
-            new Creator(
-                json.user.id,
-                json.user.username,
-                json.user.name,
-                json.user.links.html,
-                json.user.profile_image.large
-            )
-        );
+            sourceUrl: json.links.html,
+            creator: {
+                id: json.user.id,
+                username: json.user.username,
+                name: json.user.name,
+                sourceUrl: json.user.links.html,
+                imageUrl: json.user.profile_image.large
+            }
+        });
     }
 }
 

--- a/packages/posts/serverless/handlers/getPosts/index.js
+++ b/packages/posts/serverless/handlers/getPosts/index.js
@@ -34,8 +34,8 @@ export default (event, context, callback) => {
                     const sortedPosts = flattenedPosts.sort(util.sortPostsByDate);
                     const paginatedPosts = sortedPosts.slice(0, parsedQuerystringParameters && parsedQuerystringParameters.perPage || 100);
                     const globalTotal = postSearchResult.total + photoSearchResult.total;
-                    const globalFirst = _.sortBy([postSearchResult, photoSearchResult], (a, b) => a && b && a.first && b.first && a.first.dateCreated && b.first.dateCreated && a.first.dateCreated < b.first.dateCreated)[0].first;
-                    const globalLast = _.sortBy([postSearchResult, photoSearchResult], (a, b) => a && b && a.last && b.last && a.last.dateCreated && b.last.dateCreated && a.last.dateCreated > b.last.dateCreated)[0].last;
+                    const globalFirst = _.sortBy([postSearchResult, photoSearchResult], (a, b) => a && b && a.first && b.first && a.first.date && b.first.date && a.first.date < b.first.date)[0].first;
+                    const globalLast = _.sortBy([postSearchResult, photoSearchResult], (a, b) => a && b && a.last && b.last && a.last.date && b.last.date && a.last.date > b.last.date)[0].last;
 
                     return {
                         posts: paginatedPosts,

--- a/packages/posts/serverless/util/response/buildPostsResponse.js
+++ b/packages/posts/serverless/util/response/buildPostsResponse.js
@@ -18,8 +18,8 @@ export const buildPostsV2ResponseBody = ({posts, total, first, last}) => {
     return {
         posts,
         total,
-        oldest: first && first.dateCreated && first.dateCreated.toISO(),
-        newest: last && last.dateCreated && last.dateCreated.toISO(),
+        oldest: first && first.date && first.date.toISO(),
+        newest: last && last.date && last.date.toISO(),
     };
 };
 

--- a/packages/posts/test/integration/db/models/post.js
+++ b/packages/posts/test/integration/db/models/post.js
@@ -38,7 +38,7 @@ describe("Post", function () {
             width: -1,
             height: -2,
             sizedPhotos: [
-                new SizedPhoto("meow://meow.meow/meow/meowto", 640, 480)
+                SizedPhoto.fromJSON({url: "meow://meow.meow/meow/meowto", width: 640, height: 480})
             ],
             title: "Meow meow meow",
             body: [
@@ -81,7 +81,7 @@ describe("Post", function () {
             expect(createdPhoto.id).to.eql(stubPhoto.id);
             expect(createdPhoto.uid).to.eql(stubPhoto.uid);
             expect(createdPhoto.sizedPhotos).to.be.ok;
-            expect(createdPhoto.sizedPhotos).to.have.length(stubPhoto.sizedPhotos.length);
+            expect(createdPhoto.sizedPhotos.size).to.eql(stubPhoto.sizedPhotos.size);
             expect(createdPhoto).to.be.instanceof(Photo);
             const photoFromDb = await PostModel.get(createdPhoto.uid);
             expect(photoFromDb).to.be.ok;
@@ -122,7 +122,6 @@ describe("Post", function () {
             expect(createdPosts).to.have.length(stubPosts.length);
             return await Promise.all(stubPosts.map(async createdPost => {
                 expect(createdPost).to.be.ok;
-                expect(createdPost).to.be.instanceOf(Post);
                 expect(createdPost.uid).to.be.ok;
                 const postFromDb = await PostModel.get(createdPost.uid);
                 expect(postFromDb).to.be.ok;
@@ -142,7 +141,7 @@ describe("Post", function () {
                     width: -1,
                     height: -2,
                     sizedPhotos: [
-                        new SizedPhoto("grr://grr.grr/grr/grrto", 640, 480)
+                        SizedPhoto.fromJSON({url: "grr://grr.grr/grr/grrto", width: 640, height: 480})
                     ],
                     title: "Grr grr grr",
                     body: [
@@ -180,7 +179,7 @@ describe("Post", function () {
                     width: -1,
                     height: -2,
                     sizedPhotos: [
-                        new SizedPhoto("grr://grr.grr/grr/grrto", 640, 480)
+                        SizedPhoto.fromJSON({url: "grr://grr.grr/grr/grrto", width: 640, height: 480})
                     ],
                     title: "Grr grr grr",
                     body: [
@@ -244,7 +243,7 @@ describe("Post", function () {
                     width: -1,
                     height: -2,
                     sizedPhotos: [
-                        new SizedPhoto("grr://grr.grr/grr/grrto", 640, 480)
+                        SizedPhoto.fromJSON({url: "grr://grr.grr/grr/grrto", width: 640, height: 480})
                     ],
                     title: "Grr grr grr",
                     body: [
@@ -291,7 +290,7 @@ describe("Post", function () {
                     width: -1,
                     height: -2,
                     sizedPhotos: [
-                        new SizedPhoto("grr://grr.grr/grr/grrto", 640, 480)
+                        SizedPhoto.fromJSON({url: "grr://grr.grr/grr/grrto", width: 640, height: 480})
                     ],
                     title: "Grr grr grr",
                     body: [
@@ -324,7 +323,7 @@ describe("Post", function () {
                     width: -1,
                     height: -2,
                     sizedPhotos: [
-                        new SizedPhoto("grr://grr.grr/grr/grrto", 640, 480)
+                        SizedPhoto.fromJSON({url: "grr://grr.grr/grr/grrto", width: 640, height: 480})
                     ],
                     title: "Grr grr grr",
                     body: [
@@ -371,7 +370,7 @@ describe("Post", function () {
                     width: -1,
                     height: -2,
                     sizedPhotos: [
-                        new SizedPhoto("grr://grr.grr/grr/grrto", 640, 480)
+                        SizedPhoto.fromJSON({url: "grr://grr.grr/grr/grrto", width: 640, height: 480})
                     ],
                     title: "Grr grr grr",
                     body: [

--- a/packages/posts/test/integration/photos/local/photoSource.js
+++ b/packages/posts/test/integration/photos/local/photoSource.js
@@ -1,7 +1,6 @@
-import {Photo} from "@randy.tarampi/js";
+import {Photo, util} from "@randy.tarampi/js";
 import {expect} from "chai";
 import fs from "fs";
-import _ from "lodash";
 import path from "path";
 import PostModel from "../../../../db/models/post";
 import SearchParams from "../../../../lib/searchParams";
@@ -43,20 +42,11 @@ describe("LocalSource", function () {
             const stubSearchParams = SearchParams.fromJS();
 
             return photoSource.getPosts(stubSearchParams)
-                .then((photos) => {
+                .then(photos => {
                     expect(photos).to.be.ok;
-                    photos.map((photo) => {
-                        expect(photo).to.be.instanceOf(Photo);
-                    });
-                    expect(photos.length).to.be.eql(
-                        _.filter(fs.readdirSync(process.env.LOCAL_DIRECTORY), LocalSource.fileIsSupported).length
-                    );
-                    expect(photos).to.eql(
-                        _.sortBy(photos,
-                            (photo) => {
-                                return -1 * photo.dateCreated;
-                            })
-                    );
+                    expect(photos).to.have.length(fs.readdirSync(process.env.LOCAL_DIRECTORY).filter(LocalSource.fileIsSupported).length);
+                    photos.map(photo => expect(photo).to.be.instanceOf(Photo));
+                    expect(photos).to.eql(photos.sort(util.sortPostsByDate));
                 });
         });
     });
@@ -110,7 +100,7 @@ describe("LocalSource", function () {
             const jsonToPostResult = photoSource.jsonToPost(filePath, fileName, lstat, width, height);
 
             expect(jsonToPostResult).to.be.instanceof(Photo);
-            expect(jsonToPostResult.sizedPhotos.length).to.eql(1);
+            expect(jsonToPostResult.sizedPhotos.size).to.eql(1);
             jsonToPostResult.sizedPhotos.map((sizedPhoto) => {
                 expect(sizedPhoto.url).to.eql(jsonToPostResult.sourceUrl);
                 expect(sizedPhoto.width).to.eql(jsonToPostResult.width);

--- a/packages/posts/test/unit/lib/cacheClient.js
+++ b/packages/posts/test/unit/lib/cacheClient.js
@@ -68,7 +68,6 @@ describe("CacheClient", function () {
 
             const createdPosts = await cacheClient.setPosts(stubPosts);
             expect(createdPosts).to.be.ok;
-            createdPosts.map(createdPost => expect(createdPost).to.be.instanceof(Post));
             expect(stubCreatePosts.calledOnce).to.eql(true);
             expect(stubCreatePosts.calledWith(stubPosts)).to.eql(true);
         });
@@ -105,7 +104,6 @@ describe("CacheClient", function () {
 
             const retrievedPosts = await cacheClient.getPosts(stubParams);
             expect(retrievedPosts).to.be.ok;
-            retrievedPosts.map(retrievedPost => expect(retrievedPost).to.be.instanceof(Post));
             expect(stubGetPosts.calledOnce).to.eql(true);
             sinon.assert.calledWith(stubGetPosts, stubParams[cacheClient.type]);
         });

--- a/packages/posts/test/unit/photos/flickr/photoSource.js
+++ b/packages/posts/test/unit/photos/flickr/photoSource.js
@@ -58,8 +58,8 @@ describe("FlickrPhotoSource", function () {
             owner: flickrUser.owner,
             pathalias: flickrUser.owner,
             owner_name: flickrUser.owner_name,
-            datetaken: DateTime.utc().toISO(),
-            dateupload: DateTime.utc().toISO(),
+            datetaken: DateTime.utc().toSQL(),
+            dateupload: DateTime.utc().valueOf().toString(),
             width_o: 1080,
             height_o: 1080,
             url_o: "woof://woof.woof/?size=o",
@@ -249,6 +249,22 @@ describe("FlickrPhotoSource", function () {
                     expect(error).to.be.ok;
                     expect(error.message).to.match(/Please specify an actual postGetter implementation/);
                 });
+        });
+    });
+
+    describe("#jsonToPost", function () {
+        it("turns a flickr response into a `Photo`", function () {
+            const flickrPhotoSource = new FlickrPhotoSource(stubServiceClient, stubCacheClient);
+            expect(flickrPhotoSource).to.be.instanceOf(FlickrPhotoSource);
+
+            const photoFromFlickr = flickrPhotoSource.jsonToPost(flickrPhoto);
+
+            expect(photoFromFlickr).to.be.ok;
+            expect(photoFromFlickr.id).to.eql(photoFromFlickr.id);
+            expect(photoFromFlickr.datePublished).to.be.instanceof(DateTime);
+            expect(photoFromFlickr.datePublished).to.eql(DateTime.fromMillis(parseInt(flickrPhoto.dateupload, 10) * 1000));
+            expect(photoFromFlickr.dateCreated).to.be.instanceof(DateTime);
+            expect(photoFromFlickr.dateCreated).to.eql(DateTime.fromSQL(flickrPhoto.datetaken));
         });
     });
 });

--- a/packages/posts/words/s3/wordSource.js
+++ b/packages/posts/words/s3/wordSource.js
@@ -1,7 +1,6 @@
 import {Post} from "@randy.tarampi/js";
 import Aws from "aws-sdk";
 import jsyaml from "js-yaml";
-import {DateTime} from "luxon";
 import WordSource from "../wordSource";
 
 class S3WordSource extends WordSource {
@@ -38,15 +37,13 @@ class S3WordSource extends WordSource {
     }
 
     jsonToPost(postJson) {
-        return new Post(
-            postJson.Key,
-            null,
-            this.type,
-            DateTime.fromISO(postJson.date),
-            null,
-            postJson.title,
-            postJson.body
-        );
+        return Post.fromJSON({
+            id: postJson.Key,
+            source: this.type,
+            datePublished: postJson.date,
+            title: postJson.title,
+            body: postJson.body
+        });
     }
 }
 

--- a/packages/posts/words/tumblr/wordSource.js
+++ b/packages/posts/words/tumblr/wordSource.js
@@ -1,4 +1,4 @@
-import {Creator, Post} from "@randy.tarampi/js";
+import {Post} from "@randy.tarampi/js";
 import {DateTime} from "luxon";
 import tumblr from "tumblr.js";
 import {processCaptionHtml} from "../../photos/tumblr/photoSource";
@@ -36,17 +36,20 @@ class TumblrWordSource extends WordSource {
         const timezone = dateString.slice(-3);
         const date = DateTime.fromSQL(dateStringWithoutTimezone, {zone: timezone});
 
-        return new Post(
-            postJson.id,
-            null,
-            this.type,
-            date,
-            null,
-            postJson.title,
-            processCaptionHtml(postJson.body),
-            postJson.post_url,
-            blogJson && new Creator(blogJson.name, blogJson.name, blogJson.title, blogJson.url)
-        );
+        return Post.fromJS({
+            id: postJson.id,
+            source: this.type,
+            datePublished: date,
+            title: postJson.title,
+            body: processCaptionHtml(postJson.body),
+            sourceUrl: postJson.post_url,
+            creator: blogJson && {
+                id: blogJson.name,
+                username: blogJson.name,
+                name: blogJson.title,
+                sourceUrl: blogJson.url
+            }
+        });
     }
 }
 

--- a/packages/www/public/routes/index.js
+++ b/packages/www/public/routes/index.js
@@ -1,4 +1,4 @@
-import {Error, Posts} from "@randy.tarampi/jsx";
+import {Posts} from "@randy.tarampi/jsx";
 import Resume from "jsonresume-theme-randytarampi/public/components/resume";
 import React, {Fragment} from "react";
 import Helmet from "react-helmet";
@@ -48,10 +48,6 @@ const routes = [
         component: Resume,
         exact: true,
         path: "/resume"
-    },
-    {
-        component: Error,
-        path: "*"
     }
 ];
 

--- a/util.js
+++ b/util.js
@@ -1,4 +1,4 @@
 module.exports = {
-    babelLoaderExclusions: /\/node_modules\/(?!@randy\.tarampi|query-string|strict-uri-encode|strip-ansi|ansi-regex)\//,
+    babelLoaderExclusions: /\/node_modules\/(?!(?:@randy\.tarampi|query-string|strict-uri-encode|strip-ansi|ansi-regex)\/)/,
     babelRegisterInclusions: /\/(?:node_modules\/(?:@randy\.tarampi|query-string|strict-uri-encode|strip-ansi|ansi-regex)|packages)\//
 };

--- a/webpack.client.config.base.js
+++ b/webpack.client.config.base.js
@@ -7,8 +7,7 @@ const SentryPlugin = require("webpack-sentry-plugin");
 const util = require("./util");
 
 const isDevelopment = process.env.WEBPACK_SERVE
-    || process.env.NODE_ENV !== "production"
-    || process.env.NODE_ENV !== "prd"
+    || !["production", "prd"].includes(process.env.NODE_ENV)
     || true;
 
 const resolveMode = () => {
@@ -19,25 +18,7 @@ const resolveMode = () => {
     return "production";
 };
 
-const plugins = [
-    new webpack.DefinePlugin({
-        __WORDS_SERVICE_URL__: JSON.stringify(config.get("wordsServiceUrl")),
-        __POSTS_SERVICE_URL__: JSON.stringify(config.get("postsServiceUrl")),
-        __PHOTOS_SERVICE_URL__: JSON.stringify(config.get("photosServiceUrl")),
-        __CODE_APP_URL__: JSON.stringify(config.get("codeAppUrl")),
-        __WORDS_APP_URL__: JSON.stringify(config.get("wordsAppUrl")),
-        __POSTS_APP_URL__: JSON.stringify(config.get("postsAppUrl")),
-        __PHOTOS_APP_URL__: JSON.stringify(config.get("photosAppUrl")),
-        __RESUME_APP_URL__: JSON.stringify(config.get("resumeAppUrl")),
-        __ASSET_URL__: JSON.stringify(config.get("assetUrl")),
-        __PUBLISHED_RESUME_URL__: JSON.stringify(config.get("resume.publishUrl")),
-        __CAMPAIGN_SOURCE__: JSON.stringify(config.get("me.campaign.source")),
-        __CAMPAIGN_MEDIUM__: JSON.stringify(config.get("me.campaign.medium")),
-        __CAMPAIGN_NAME__: JSON.stringify(config.get("me.campaign.name")),
-        __CAMPAIGN_TERM__: JSON.stringify(config.get("me.campaign.term")),
-        __CAMPAIGN_CONTENT__: JSON.stringify(config.get("me.campaign.content"))
-    })
-];
+const plugins = [];
 
 if (process.env.DEPLOY && process.env.SENTRY_AUTH_TOKEN) {
     plugins.push(


### PR DESCRIPTION
Close #23 and do a bunch of cleanup stuff I've been deferring for ages.

Meat
---
- 807c805 – Entities defined in `@randy.tarampi/js` are `Immutable.Record`s.
- 595b9ca, b353a00 – Make the redux state immutable. 

Sides
---
- 539d54e – Use `Post#datePublished` instead of `Post#dateCreated` for sorting.
- ecdb1ea – Correctly parse Flickr responses' `dateTaken` property. Why they use two different date formats in the same JSON response I don't know. I mean, why not save that change for an API version bump?

Dessert
---
- fa27adc, 6f3f865 – Just use `babel-plugin-minify-replace` to replace global values with strings instead of mixing that with `Webpack.DefinePlugin`.
- 02f87ab – Stop babel from compiling `node_modules` by fixing the incorrect `babelLoaderExclusions` regex.
- 7b1e953, b353a00 – Avoid having to redirect people to an `/error` page by just wrapping the router component in a connected component that just shows an error when we have one.