### PR TITLE
feat(posts): Actually load *all* Posts from each service per #73.

### DIFF
--- a/packages/js/lib/util/sortCharactersByPosition.js
+++ b/packages/js/lib/util/sortCharactersByPosition.js
@@ -1,5 +1,5 @@
 /**
- * @function Sort two [Character]{@link Character}s by position, ascending.
+ * @function Sort two [Characters]{@link Character} by position, ascending.
  * @param a {Character}
  * @param b {Character}
  * @returns {number}

--- a/packages/js/lib/util/sortPhotosByWidth.js
+++ b/packages/js/lib/util/sortPhotosByWidth.js
@@ -1,5 +1,5 @@
 /**
- * @function Sort two [Photos]{@link Photo}s by width, ascending.
+ * @function Sort two [Photos]{@link Photo} by width, ascending.
  * @param a {Photo}
  * @param b {Photo}
  * @returns {number}

--- a/packages/js/lib/util/sortPostsByDate.js
+++ b/packages/js/lib/util/sortPostsByDate.js
@@ -1,5 +1,5 @@
 /**
- * @function Sort two [Post]{@link Post}s by date, descending.
+ * @function Sort two [Posts]{@link Post} by date, descending.
  * @param a {Post}
  * @param b {Post}
  * @returns {number}

--- a/packages/posts/lib/dataSource.js
+++ b/packages/posts/lib/dataSource.js
@@ -67,6 +67,29 @@ class DataSource {
     }
 
     /**
+     * The method that actually uses the [client]{@link DataSource.client} to query for raw data for transformation into [Posts]{@link Post}
+     * @abstract
+     * @param searchParams {SearchParams} [Client]{@link DataSource.client} specific query parameters
+     * @returns {Post[]} [Post]{@link Post} entities transformed from data retrieved from the wrapped client
+     */
+    async allPostsGetter(searchParams) {
+        return Promise.reject(new Error(`Looking for ${searchParams} – Please specify an actual allPostsGetter implementation`));
+    }
+
+    /**
+     * A generic method that returns all available [Posts]{@link Post}
+     * @param searchParams {SearchParams} [Client]{@link DataSource.client} specific query parameters
+     * @returns {Post[]} [Post]{@link Post} entities transformed from data retrieved from the wrapped client
+     */
+    async getAllPosts(searchParams) {
+        const decoratedParams = await this.beforePostsGetter(searchParams);
+        const retrievedPosts = await this.allPostsGetter(decoratedParams);
+        const decoratedPosts = await this.afterPostsGetter(retrievedPosts, decoratedParams);
+
+        return decoratedPosts;
+    }
+
+    /**
      * A hook to do some processing of searchParams before we query the client for a post
      * @param postId {string} A single post to retrieve from the [client]{@link DataSource.client}
      * @param searchParams {SearchParams} [Client]{@link DataSource.client} specific query parameters

--- a/packages/posts/lib/searchParams.js
+++ b/packages/posts/lib/searchParams.js
@@ -20,6 +20,7 @@ const searchParamsRecordDefinition = {
     orderOperator: undefined,
     orderComparator: undefined,
     orderComparatorType: undefined,
+    all: false,
 
     // NOTE-RT: For individual posts
     width: undefined,
@@ -91,7 +92,8 @@ class SearchParams extends SearchParamsRecord {
 
     get Dynamoose() {
         const options = {
-            descending: true
+            descending: true,
+            all: this.all
         };
 
         switch (this.orderBy) {

--- a/packages/posts/lib/searchParams.js
+++ b/packages/posts/lib/searchParams.js
@@ -1,10 +1,11 @@
 import {Photo, util} from "@randy.tarampi/js";
 import {Record} from "immutable";
 import _ from "lodash";
+import {DateTime} from "luxon";
 
 /**
  * @typedef {Object} searchParamsRecordDefinition
- * @type {{type: undefined, perPage: number, page: number, orderBy: undefined, orderOperator: undefined, orderComparator: undefined, orderComparatorType: undefined, width: undefined, height: undefined, crop: undefined, id: undefined, uid: undefined, source: undefined, _rawFilter: undefined}}
+ * @type {{type: string, perPage: number, page: number, orderBy: string, orderOperator: string, orderComparator: string, orderComparatorType: string, width: number, height: number, crop: undefined, id: string, uid: string, source: string, _rawFilter: object, all: boolean, beforeDate: DateTime, beforeId: string, afterId: string, continuationToken: string}}
  * @property orderBy {String} One of `ascending` or `descending`.
  */
 const searchParamsRecordDefinition = {
@@ -21,6 +22,10 @@ const searchParamsRecordDefinition = {
     orderComparator: undefined,
     orderComparatorType: undefined,
     all: false,
+    beforeDate: null,
+    beforeId: null,
+    afterId: null,
+    continuationToken: null,
 
     // NOTE-RT: For individual posts
     width: undefined,
@@ -39,7 +44,7 @@ class SearchParams extends SearchParamsRecord {
     get Flickr() {
         return {
             page: this.page,
-            per_page: this.perPage,
+            per_page: Math.min(this.perPage, 500),
             extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description"
         };
     }
@@ -68,9 +73,24 @@ class SearchParams extends SearchParamsRecord {
     }
 
     get Instagram() {
-        return {
+        const baseRequest = {
             page: this.page,
             count: this.perPage
+        };
+
+        const filterRequest = {};
+
+        if (this.beforeId) {
+            filterRequest.max_id = this.beforeId;
+        }
+
+        if (this.afterId) {
+            filterRequest.min_id = this.afterId;
+        }
+
+        return {
+            ...baseRequest,
+            ...filterRequest
         };
     }
 
@@ -81,12 +101,24 @@ class SearchParams extends SearchParamsRecord {
             type = "photo";
         }
 
-        return {
+        const baseRequest = {
             type,
             id: this.id,
-            limit: this.perPage,
+            limit: Math.min(this.perPage, 20)
+        };
+
+        const filterRequest = {
             page: this.page,
-            offset: this.perPage * (this.page - 1)
+            offset: baseRequest.limit * (this.page - 1)
+        };
+
+        if (this.beforeDate) {
+            filterRequest.before = this.beforeDate.valueOf() / 1000 - 1;
+        }
+
+        return {
+            ...baseRequest,
+            ...filterRequest
         };
     }
 
@@ -202,30 +234,63 @@ class SearchParams extends SearchParamsRecord {
     }
 
     get S3() {
-        const params = {
+        const baseRequest = {
             Bucket: process.env.S3_BUCKET_NAME
         };
 
         if (this.id) {
             return {
-                ...params,
+                ...baseRequest,
                 Key: this.id
             };
         }
 
+        const filterRequest = {};
+
+        if (this.beforeId) {
+            filterRequest.StartAfter = this.beforeId;
+        }
+        if (this.continuationToken) {
+            filterRequest.ContinuationToken = this.continuationToken;
+        }
+
         return {
-            ...params,
-            MaxKeys: this.perPage,
-            Marker: String(this.perPage * (this.page - 1)), // FIXME-RT: Replace with `StartAfter`
+            ...baseRequest,
+            ...filterRequest,
+            MaxKeys: Math.min(this.perPage, 1000)
         };
     }
 
-    static fromJS(json) {
-        return new SearchParams({
+    static parsePropertiesFromJs(js) {
+        return {
+            orderBy: "descending",
+            all: false,
+            perPage: 100,
+            page: 1,
+            ...js,
+            beforeDate: js && js.beforeDate ? DateTime.fromMillis(js.beforeDate.valueOf()) : null
+        };
+    }
+
+    static fromJS(js) {
+        return new SearchParams(SearchParams.parsePropertiesFromJs(js));
+    }
+
+    static parsePropertiesFromJson(json) {
+        return {
+            orderBy: "descending",
+            all: false,
             ...json,
-            perPage: json && json.perPage && parseInt(json.perPage, 10),
-            page: json && json.page && parseInt(json.page, 10)
-        });
+            width: json && json.width ? parseInt(json.width, 10) : undefined,
+            height: json && json.width ? parseInt(json.height, 10) : undefined,
+            beforeDate: json && json.beforeDate ? DateTime.fromISO(json.beforeDate) : null,
+            perPage: json && json.perPage ? parseInt(json.perPage, 10) : 100,
+            page: json && json.page ? parseInt(json.page, 10) : 1
+        };
+    }
+
+    static fromJSON(json) {
+        return new SearchParams(SearchParams.parsePropertiesFromJson(json));
     }
 }
 

--- a/packages/posts/photos/cachePhotos.js
+++ b/packages/posts/photos/cachePhotos.js
@@ -6,7 +6,7 @@ const cachePhotos = photoSearchParams => {
         .then(photoSources => {
             return Promise.all(
                 photoSources.map((photoSource) => {
-                    return photoSource.getServicePosts(photoSearchParams)
+                    return photoSource.getAllServicePosts(photoSearchParams)
                         .catch((error) => {
                             logger.error(error);
                             return [];

--- a/packages/posts/photos/flickr/photoSource.js
+++ b/packages/posts/photos/flickr/photoSource.js
@@ -36,6 +36,20 @@ class FlickrSource extends PhotoSource {
             });
     }
 
+    async allPostsGetter(searchParams) {
+        let posts = await this.postsGetter(searchParams);
+
+        if (posts.length) {
+            posts = posts.concat(await this.allPostsGetter(
+                searchParams
+                    .set("all", true)
+                    .set("page", searchParams.page + 1)
+            ));
+        }
+
+        return posts;
+    }
+
     jsonToPost(json) {
         return Photo.fromJS({
             id: json.id,

--- a/packages/posts/photos/instagram/photoSource.js
+++ b/packages/posts/photos/instagram/photoSource.js
@@ -38,6 +38,21 @@ class InstagramSource extends PhotoSource {
             ));
     }
 
+    async allPostsGetter(searchParams) {
+        let posts = await this.postsGetter(searchParams);
+
+        if (posts.length) {
+            const lastPost = posts[posts.length - 1];
+            posts = posts.concat(await this.allPostsGetter(
+                searchParams
+                    .set("all", true)
+                    .set("beforeId", lastPost)
+            ));
+        }
+
+        return posts;
+    }
+
     postGetter(photoId) {
         return this.client.media(photoId)
             .then(postJson => postJson && postJson.data && this._highResolutionPhotoGetter(postJson.data).then(post => this.jsonToPost(post)));
@@ -76,7 +91,7 @@ class InstagramSource extends PhotoSource {
             title: photoJson.location && photoJson.location.name,
             body: photoJson.caption && photoJson.caption.text,
             creator: {
-                id: photoJson.user.username,
+                id: photoJson.user.id,
                 username: photoJson.user.username,
                 name: photoJson.user.full_name,
                 sourceUrl: `https://www.instagram.com/${photoJson.user.username}`

--- a/packages/posts/photos/unsplash/photoSource.js
+++ b/packages/posts/photos/unsplash/photoSource.js
@@ -21,6 +21,20 @@ class UnsplashSource extends PhotoSource {
             .then(response => Promise.all(response.map(photo => this.jsonToPost(photo)))); // NOTE-RT: Need `that` because `toJson` uses an old school `function`
     }
 
+    async allPostsGetter(searchParams) {
+        let posts = await this.postsGetter(searchParams);
+
+        if (posts.length) {
+            posts = posts.concat(await this.allPostsGetter(
+                searchParams
+                    .set("all", true)
+                    .set("page", searchParams.page + 1)
+            ));
+        }
+
+        return posts;
+    }
+
     postGetter(photoId, searchParams) {
         return this.client.photos.getPost(photoId, searchParams.Unsplash.width, searchParams.Unsplash.height, searchParams.Unsplash.crop)
             .then(toJson)

--- a/packages/posts/test/integration/photos/local/photoSource.js
+++ b/packages/posts/test/integration/photos/local/photoSource.js
@@ -37,11 +37,25 @@ describe("LocalSource", function () {
 
     describe("#getPosts", function () {
         it("should load `Photo`s from the most recent images in the given `process.env.LOCAL_DIRECTORY`", function () {
-
             const photoSource = new LocalSource();
             const stubSearchParams = SearchParams.fromJS();
 
             return photoSource.getPosts(stubSearchParams)
+                .then(photos => {
+                    expect(photos).to.be.ok;
+                    expect(photos).to.have.length(fs.readdirSync(process.env.LOCAL_DIRECTORY).filter(LocalSource.fileIsSupported).length);
+                    photos.map(photo => expect(photo).to.be.instanceOf(Photo));
+                    expect(photos).to.eql(photos.sort(util.sortPostsByDate));
+                });
+        });
+    });
+
+    describe("#allPostsGetter", function () {
+        it("should load `Photo`s from the most recent images in the given `process.env.LOCAL_DIRECTORY`", function () {
+            const photoSource = new LocalSource();
+            const stubSearchParams = SearchParams.fromJS();
+
+            return photoSource.allPostsGetter(stubSearchParams)
                 .then(photos => {
                     expect(photos).to.be.ok;
                     expect(photos).to.have.length(fs.readdirSync(process.env.LOCAL_DIRECTORY).filter(LocalSource.fileIsSupported).length);

--- a/packages/posts/test/lib/dummyCachedDataSourceGenerator.js
+++ b/packages/posts/test/lib/dummyCachedDataSourceGenerator.js
@@ -1,26 +1,30 @@
 import CachedDataSource from "../../lib/cachedDataSource";
 
 export const DummyCachedDataSourceGenerator = ({
-                    stubIsEnabled = () => true,
+                                                   stubIsEnabled = () => true,
 
-                    stubBeforePostsGetter,
-                    stubPostsGetter,
-                    stubAfterPostsGetter,
+                                                   stubBeforePostsGetter,
+                                                   stubPostsGetter,
+                                                   stubAfterPostsGetter,
 
-                    stubBeforePostGetter,
-                    stubPostGetter,
-                    stubAfterPostGetter,
+                                                   stubAllPostsGetter,
 
-                    stubBeforeCachedPostsGetter,
-                    stubCachedPostsGetter,
-                    stubAfterCachedPostsGetter,
+                                                   stubBeforePostGetter,
+                                                   stubPostGetter,
+                                                   stubAfterPostGetter,
 
-                    stubBeforeCachedPostGetter,
-                    stubCachedPostGetter,
-                    stubAfterCachedPostGetter,
+                                                   stubBeforeCachedPostsGetter,
+                                                   stubCachedPostsGetter,
+                                                   stubAfterCachedPostsGetter,
 
-                    stubJsonToPost
-                }) => {
+                                                   stubAllCachedPostsGetter,
+
+                                                   stubBeforeCachedPostGetter,
+                                                   stubCachedPostGetter,
+                                                   stubAfterCachedPostGetter,
+
+                                                   stubJsonToPost
+                                               }) => {
 
     return class DummyCachedDataSource extends CachedDataSource {
         get isEnabled() {
@@ -37,6 +41,10 @@ export const DummyCachedDataSourceGenerator = ({
 
         async afterPostsGetter(posts, params) {
             return stubAfterPostsGetter(posts, params);
+        }
+
+        async allPostsGetter(posts, params) {
+            return stubAllPostsGetter(posts, params);
         }
 
         async beforePostGetter(postId, params) {
@@ -61,6 +69,10 @@ export const DummyCachedDataSourceGenerator = ({
 
         async afterCachedPostsGetter(posts, params) {
             return stubAfterCachedPostsGetter(posts, params);
+        }
+
+        async allCachedPostsGetter(posts, params) {
+            return stubAllCachedPostsGetter(posts, params);
         }
 
         async beforeCachedPostGetter(postId, params) {

--- a/packages/posts/test/lib/dummyClassesGenerator.js
+++ b/packages/posts/test/lib/dummyClassesGenerator.js
@@ -7,6 +7,8 @@ export const dummyClassesGenerator = ({
                                           stubPostsGetter,
                                           stubAfterPostsGetter,
 
+                                          stubAllPostsGetter,
+
                                           stubBeforePostGetter,
                                           stubPostGetter,
                                           stubAfterPostGetter,
@@ -14,6 +16,8 @@ export const dummyClassesGenerator = ({
                                           stubBeforeCachedPostsGetter,
                                           stubCachedPostsGetter,
                                           stubAfterCachedPostsGetter,
+
+                                          stubAllCachedPostsGetter,
 
                                           stubBeforeCachedPostGetter,
                                           stubCachedPostGetter,
@@ -33,6 +37,8 @@ export const dummyClassesGenerator = ({
             stubPostsGetter,
             stubAfterPostsGetter,
 
+            stubAllPostsGetter,
+
             stubBeforePostGetter,
             stubPostGetter,
             stubAfterPostGetter,
@@ -40,6 +46,8 @@ export const dummyClassesGenerator = ({
             stubBeforeCachedPostsGetter,
             stubCachedPostsGetter,
             stubAfterCachedPostsGetter,
+
+            stubAllCachedPostsGetter,
 
             stubBeforeCachedPostGetter,
             stubCachedPostGetter,

--- a/packages/posts/test/lib/dummyDataSourceGenerator.js
+++ b/packages/posts/test/lib/dummyDataSourceGenerator.js
@@ -1,18 +1,19 @@
 import DataSource from "../../lib/dataSource";
 
 export const DummyDataSourceGenerator = ({
-                    stubIsEnabled = () => true,
+                                             stubIsEnabled = () => true,
 
-                    stubBeforePostsGetter,
-                    stubPostsGetter,
-                    stubAfterPostsGetter,
+                                             stubBeforePostsGetter,
+                                             stubPostsGetter,
+                                             stubAfterPostsGetter,
+                                             stubAllPostsGetter,
 
-                    stubBeforePostGetter,
-                    stubPostGetter,
-                    stubAfterPostGetter,
+                                             stubBeforePostGetter,
+                                             stubPostGetter,
+                                             stubAfterPostGetter,
 
-                    stubJsonToPost
-                }) => {
+                                             stubJsonToPost
+                                         }) => {
 
     return class DummyDataSource extends DataSource {
         get isEnabled() {
@@ -29,6 +30,10 @@ export const DummyDataSourceGenerator = ({
 
         async afterPostsGetter(posts, params) {
             return stubAfterPostsGetter(posts, params);
+        }
+
+        async allPostsGetter(posts, params) {
+            return stubAllPostsGetter(posts, params);
         }
 
         async beforePostGetter(postId, params) {

--- a/packages/posts/test/unit/lib/searchParams.js
+++ b/packages/posts/test/unit/lib/searchParams.js
@@ -127,7 +127,7 @@ describe("SearchParams", function () {
                 _query: {
                     uid: {eq: "woof"}
                 },
-                _options: {limit: 100, descending: true}
+                _options: {limit: 100, descending: true, all: false}
             });
         });
 
@@ -138,7 +138,7 @@ describe("SearchParams", function () {
                 _query: {
                     uid: {eq: "woof"}
                 },
-                _options: {limit: 100, descending: true}
+                _options: {limit: 100, descending: true, all: false}
             });
         });
 
@@ -149,7 +149,7 @@ describe("SearchParams", function () {
                 _query: {
                     uid: {eq: "woof"}
                 },
-                _options: {limit: 100, descending: false}
+                _options: {limit: 100, descending: false, all: false}
             });
         });
 
@@ -160,7 +160,7 @@ describe("SearchParams", function () {
                 _query: {
                     type: {eq: "woof"}
                 },
-                _options: {limit: 100, descending: true}
+                _options: {limit: 100, descending: true, all: false}
             });
         });
 
@@ -171,7 +171,7 @@ describe("SearchParams", function () {
                 _query: {
                     source: {eq: "meow"},
                 },
-                _options: {limit: 100, descending: true}
+                _options: {limit: 100, descending: true, all: false}
             });
         });
 
@@ -183,7 +183,7 @@ describe("SearchParams", function () {
                     hash: {type: {eq: "woof"}},
                     range: {source: {eq: "meow"}},
                 },
-                _options: {indexName: "type-source-index", limit: 100, descending: true}
+                _options: {indexName: "type-source-index", limit: 100, descending: true, all: false}
             });
         });
 
@@ -200,7 +200,7 @@ describe("SearchParams", function () {
                     hash: {type: {eq: "woof"}},
                     range: {meow: {lt: 0}}
                 },
-                _options: {indexName: "type-meow-index", limit: 100, descending: true}
+                _options: {indexName: "type-meow-index", limit: 100, descending: true, all: false}
             });
         });
 
@@ -211,7 +211,7 @@ describe("SearchParams", function () {
                 _query: {
                     uid: {eq: `meow${util.compositeKeySeparator}woof`}
                 },
-                _options: {limit: 100, descending: true}
+                _options: {limit: 100, descending: true, all: false}
             });
         });
 
@@ -228,7 +228,7 @@ describe("SearchParams", function () {
                     hash: {source: {eq: "woof"}},
                     range: {meow: {gt: 5}}
                 },
-                _options: {indexName: "source-meow-index", limit: 100, descending: true}
+                _options: {indexName: "source-meow-index", limit: 100, descending: true, all: false}
             });
         });
 
@@ -250,7 +250,8 @@ describe("SearchParams", function () {
                 _options: {
                     indexName: "source-meow-index",
                     limit: 20,
-                    descending: true
+                    descending: true,
+                    all: false
                 }
             });
         });

--- a/packages/posts/test/unit/lib/searchParams.js
+++ b/packages/posts/test/unit/lib/searchParams.js
@@ -101,8 +101,8 @@ describe("SearchParams", function () {
                 id: this.id,
                 type: "text",
                 page: searchParams.page,
-                limit: searchParams.perPage,
-                offset: searchParams.perPage * (searchParams.page - 1)
+                limit: 20,
+                offset: 20 * (searchParams.page - 1)
             });
         });
 
@@ -113,8 +113,8 @@ describe("SearchParams", function () {
                 id: this.id,
                 type: "photo",
                 page: searchParams.page,
-                limit: searchParams.perPage,
-                offset: searchParams.perPage * (searchParams.page - 1)
+                limit: 20,
+                offset: 20 * (searchParams.page - 1)
             });
         });
     });
@@ -263,7 +263,6 @@ describe("SearchParams", function () {
 
             expect(searchParams.S3).to.eql({
                 Bucket: process.env.S3_BUCKET_NAME,
-                Marker: "0",
                 MaxKeys: 100
             });
         });

--- a/packages/posts/words/cacheWords.js
+++ b/packages/posts/words/cacheWords.js
@@ -6,7 +6,7 @@ const cacheWords = wordSearchParams => {
         .then(wordSources => {
             return Promise.all(
                 wordSources.map((wordSource) => {
-                    return wordSource.getServicePosts(wordSearchParams)
+                    return wordSource.getAllServicePosts(wordSearchParams)
                         .catch((error) => {
                             logger.error(error);
                             return [];


### PR DESCRIPTION
Every service except for Instagram which seems to limit the `recent` media you can pull to 20 items.

Meat
---
- 9491412 – Lay the ground work for a `getAllPosts` interface.
- 6e7511f – Actually implement `getAllPosts`.

Sides
---
- 017cf74 – Cleanup some documentation.