### PR TITLE
feat(www): Add a basic service worker.

### DIFF
--- a/packages/css/gulpfile.js
+++ b/packages/css/gulpfile.js
@@ -24,6 +24,7 @@ gulp.task("lint", gulp.series(["sassLint"]));
 gulp.task("copy", () => {
     return gulp
         .src([
+            "node_modules/materialize-css/dist/fonts/roboto/**",
             "node_modules/@fortawesome/fontawesome-free/webfonts/**"
         ])
         .pipe(gulp.dest("./dist"));

--- a/packages/css/styles/nav.scss
+++ b/packages/css/styles/nav.scss
@@ -1,5 +1,13 @@
 .nav {
+    &-header__tabs {
+        min-height: 48px;
+    }
+
     &-container {
+        position: fixed;
+        width: 100%;
+        z-index: 999;
+
         .row {
             margin: 0;
 

--- a/packages/jsx/gulpfile.js
+++ b/packages/jsx/gulpfile.js
@@ -53,7 +53,10 @@ gulp.task("webpack", function (callback) {
     const Webpack = require("webpack");
     const webpackConfig = require("./webpack.client.config");
 
-    Webpack(webpackConfig, function (err, stats) {
+    Webpack(webpackConfig, function (error, stats) {
+        if (error) {
+            return callback(error);
+        }
         console.log(stats.toString({colors: true})); // eslint-disable-line no-console
         callback(stats.compilation.errors && stats.compilation.errors[0] && stats.compilation.errors[0]);
     });

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -75,6 +75,7 @@
     "react-router-config": "^1.0.0-beta.4",
     "react-router-dom": "^4.3.1",
     "react-swipeable-views": "^0.13.0",
+    "react-swipeable-views-utils": "^0.13.0",
     "redux-actions": "^2.4.0",
     "redux-devtools-extension": "^2.13.5",
     "redux-immutable": "^4.0.0",

--- a/packages/jsx/src/lib/clientSwipeableReduxRouterRoot.jsx
+++ b/packages/jsx/src/lib/clientSwipeableReduxRouterRoot.jsx
@@ -15,7 +15,7 @@ export class ClientSwipeableReduxRouterRoot extends ClientRoot {
 
         return <Provider store={store}>
             <Fragment>
-                <header>
+                <header className="nav-header nav-header__tabs nav-header__swipeable">
                     <div className="nav-container">
                         <ConnectedSwipeableTabs id="swipeable-nav-tabs" className="nav-tabs nav-tabs__swipeable">
                             {

--- a/packages/jsx/src/lib/containers/swipeableRoutes.jsx
+++ b/packages/jsx/src/lib/containers/swipeableRoutes.jsx
@@ -1,6 +1,7 @@
 import {connect} from "react-redux";
 import {withRouter} from "react-router";
 import SwipeableViews from "react-swipeable-views";
+import {bindKeyboard} from "react-swipeable-views-utils";
 import {swipeableChangeIndexCreator} from "../actions";
 import selectors from "../data/selectors";
 
@@ -23,6 +24,7 @@ export const ConnectedSwipeableRoutes = withRouter(connect(
             index,
             resistance: true,
             ignoreNativeScroll: true,
+            enableMouseEvents: true,
             hysteresis: 0.3,
             springConfig: {duration: "0.5s", easeFunction: "ease", delay: "0s"}
         };
@@ -30,6 +32,6 @@ export const ConnectedSwipeableRoutes = withRouter(connect(
     {
         onChangeIndex: swipeableChangeIndexCreator
     }
-)(SwipeableViews));
+)(bindKeyboard(SwipeableViews)));
 
 export default ConnectedSwipeableRoutes;

--- a/packages/letter/gulpfile.js
+++ b/packages/letter/gulpfile.js
@@ -122,7 +122,10 @@ gulp.task("webpack", function (callback) {
     const Webpack = require("webpack");
     const webpackConfig = require("./webpack.client.config");
 
-    Webpack(webpackConfig, function (err, stats) {
+    Webpack(webpackConfig, function (error, stats) {
+        if (error) {
+            return callback(error);
+        }
         console.log(stats.toString({colors: true})); // eslint-disable-line no-console
         callback(stats.compilation.errors && stats.compilation.errors[0] && stats.compilation.errors[0]);
     });

--- a/packages/letter/gulpfile.js
+++ b/packages/letter/gulpfile.js
@@ -17,6 +17,7 @@ gulp.task("copy", () => {
     return gulp
         .src([
             "node_modules/@randy.tarampi/assets/web/**",
+            "node_modules/@randy.tarampi/css/node_modules/materialize-css/dist/fonts/roboto/**",
             "node_modules/@randy.tarampi/css/node_modules/@fortawesome/fontawesome-free/webfonts/**"
         ])
         .pipe(gulp.dest("./dist"));

--- a/packages/resume/gulpfile.js
+++ b/packages/resume/gulpfile.js
@@ -17,6 +17,7 @@ gulp.task("copy", () => {
     return gulp
         .src([
             "node_modules/@randy.tarampi/assets/web/**",
+            "node_modules/@randy.tarampi/css/node_modules/materialize-css/dist/fonts/roboto/**",
             "node_modules/@randy.tarampi/css/node_modules/@fortawesome/fontawesome-free/webfonts/**"
         ])
         .pipe(gulp.dest("./dist"));

--- a/packages/resume/gulpfile.js
+++ b/packages/resume/gulpfile.js
@@ -124,7 +124,10 @@ gulp.task("webpack", function (callback) {
     const Webpack = require("webpack");
     const webpackConfig = require("./webpack.client.config");
 
-    Webpack(webpackConfig, function (err, stats) {
+    Webpack(webpackConfig, function (error, stats) {
+        if (error) {
+            return callback(error);
+        }
         console.log(stats.toString({colors: true})); // eslint-disable-line no-console
         callback(stats.compilation.errors && stats.compilation.errors[0] && stats.compilation.errors[0]);
     });

--- a/packages/views/templates/layout.pug
+++ b/packages/views/templates/layout.pug
@@ -98,5 +98,12 @@ html(lang="en")
             iframe(src="https://www.googletagmanager.com/ns.html?id=" + gtm height="0" width="0" style="display:none;visibility:hidden")
         block content
         if environment !== "puppeteer" && environment !== "printable"
+            if !!serviceWorkerBundleName
+                script(type="application/javascript").
+                    if ("serviceWorker" in navigator) {
+                        window.addEventListener("load", function () {
+                            navigator.serviceWorker.register("!{assetUrl}/!{serviceWorkerBundleName}.js");
+                        });
+                    }
             script(src=assetUrl + "/vendor.js")
             script(src=assetUrl + "/" + bundleName + ".js")

--- a/packages/www/gulpfile.js
+++ b/packages/www/gulpfile.js
@@ -18,6 +18,7 @@ gulp.task("copy", () => {
     return gulp
         .src([
             "node_modules/@randy.tarampi/assets/web/**",
+            "node_modules/@randy.tarampi/css/node_modules/materialize-css/dist/fonts/roboto/**",
             "node_modules/@randy.tarampi/css/node_modules/@fortawesome/fontawesome-free/webfonts/**"
         ])
         .pipe(gulp.dest("./dist"));
@@ -33,6 +34,7 @@ const buildViewForPageUrl = (basename, pageUrl = config.get("www.publishUrl")) =
         .pipe(pug({
             locals: buildPugLocals({
                 bundleName: "www",
+                serviceWorkerBundleName: "www.sw",
                 packageJson,
                 pageUrl
             })

--- a/packages/www/gulpfile.js
+++ b/packages/www/gulpfile.js
@@ -84,7 +84,10 @@ gulp.task("webpack", function (callback) {
     const Webpack = require("webpack");
     const webpackConfig = require("./webpack.client.config");
 
-    Webpack(webpackConfig, function (err, stats) {
+    Webpack(webpackConfig, function (error, stats) {
+        if (error) {
+            return callback(error);
+        }
         console.log(stats.toString({colors: true})); // eslint-disable-line no-console
         callback(stats.compilation.errors && stats.compilation.errors[0] && stats.compilation.errors[0]);
     });

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -68,6 +68,7 @@
     "nyc": "^13.0.1",
     "webpack": "^4.16.0",
     "webpack-bundle-analyzer": "^3.0.0",
-    "webpack-serve": "^2.0.2"
+    "webpack-serve": "^2.0.2",
+    "workbox-webpack-plugin": "^3.6.2"
   }
 }

--- a/packages/www/webpack.client.config.js
+++ b/packages/www/webpack.client.config.js
@@ -36,7 +36,10 @@ module.exports = webpackBaseConfig({
                     urlPattern: /.*(?:flickr|instagram|tumblr|unsplash|gravatar)\.com/,
                     handler: "staleWhileRevalidate",
                     options: {
-                        cacheName: "external"
+                        cacheName: "external",
+                        expiration: {
+                            purgeOnQuotaError: true
+                        }
                     }
                 },
                 {

--- a/packages/www/webpack.client.config.js
+++ b/packages/www/webpack.client.config.js
@@ -38,6 +38,7 @@ module.exports = webpackBaseConfig({
                     options: {
                         cacheName: "external",
                         expiration: {
+                            maxEntries: 100,
                             purgeOnQuotaError: true
                         }
                     }

--- a/packages/www/webpack.client.config.js
+++ b/packages/www/webpack.client.config.js
@@ -1,4 +1,7 @@
 const path = require("path");
+process.env.NODE_CONFIG_DIR = path.join(__dirname, "../../config");
+
+const config = require("config");
 const webpackBaseConfig = require("../../webpack.client.config.base");
 const serve = require("koa-static");
 const mount = require("koa-mount");
@@ -41,6 +44,13 @@ module.exports = webpackBaseConfig({
                             maxEntries: 100,
                             purgeOnQuotaError: true
                         }
+                    }
+                },
+                {
+                    urlPattern: new RegExp("^" + config.get("posts.postsUrl")),
+                    handler: "staleWhileRevalidate",
+                    options: {
+                        cacheName: "posts"
                     }
                 },
                 {

--- a/packages/www/webpack.client.config.js
+++ b/packages/www/webpack.client.config.js
@@ -2,6 +2,8 @@ const path = require("path");
 const webpackBaseConfig = require("../../webpack.client.config.base");
 const serve = require("koa-static");
 const mount = require("koa-mount");
+const WorkboxPlugin = require("workbox-webpack-plugin");
+const packageJson = require("./package");
 
 module.exports = webpackBaseConfig({
     sourceDirectoryPath: __dirname,
@@ -13,5 +15,45 @@ module.exports = webpackBaseConfig({
     entry: {
         www: ["@babel/polyfill", "raf/polyfill", path.join(__dirname, "./public/views/index.jsx")],
         styles: path.join(__dirname, "./styles/style.scss")
-    }
+    },
+    plugins: [
+        new WorkboxPlugin.GenerateSW({
+            swDest: "www.sw.js",
+            skipWaiting: true,
+            clientsClaim: true,
+            offlineGoogleAnalytics: true,
+            maximumFileSizeToCacheInBytes: 20 * 1024 * 1024,
+            cacheId: packageJson.name,
+            runtimeCaching: [
+                {
+                    urlPattern: /\.(?:png|jpg|jpeg|eot|ttf|woff|woff2|svg|gif|ico)$/,
+                    handler: "staleWhileRevalidate",
+                    options: {
+                        cacheName: "assets"
+                    }
+                },
+                {
+                    urlPattern: /.*(?:flickr|instagram|tumblr|unsplash|gravatar)\.com/,
+                    handler: "staleWhileRevalidate",
+                    options: {
+                        cacheName: "external"
+                    }
+                },
+                {
+                    urlPattern: /^https:\/\/fonts\.googleapis\.com/,
+                    handler: "staleWhileRevalidate",
+                    options: {
+                        cacheName: "google-fonts-stylesheets"
+                    }
+                },
+                {
+                    urlPattern: /^https:\/\/fonts\.gstatic\.com/,
+                    handler: "staleWhileRevalidate",
+                    options: {
+                        cacheName: "google-fonts-webfonts"
+                    }
+                }
+            ]
+        })
+    ]
 });

--- a/webpack.client.config.base.js
+++ b/webpack.client.config.base.js
@@ -53,7 +53,7 @@ if (process.env.DEPLOY && process.env.SENTRY_AUTH_TOKEN) {
     );
 }
 
-module.exports = ({sourceDirectoryPath, compliationDirectoryPath, webpackServeMiddleware, ...configOverrides}) => {
+module.exports = ({sourceDirectoryPath, compliationDirectoryPath, webpackServeMiddleware, plugins: otherPlugins = [], ...configOverrides}) => {
     return {
         mode: resolveMode(),
         devtool: "nosources-source-map",
@@ -108,7 +108,7 @@ module.exports = ({sourceDirectoryPath, compliationDirectoryPath, webpackServeMi
                 }
             ]
         },
-        plugins,
+        plugins: plugins.concat(otherPlugins),
         serve: {
             clipboard: false,
             content: compliationDirectoryPath,


### PR DESCRIPTION
Per #145. It'd be nice if this did something fancy like ask for push notification permissions on content updates, but we can leave that until later.

Just cache things for now and see what offline GA looks like.

Meat
---
- b833e23, 0c03512...9667f65 – Add a basic service worker that caches some assets.
- 90966c6 – See if we can cache `posts.postsUrl` responses.

Sides
---
- 4fd3b94 – Copy `Roboto` since `materialize-css@0.100.2` is now pulling that in.
- b9349f0 – Webpack errors should fail the build.

Dessert
---
- 6cbb773 – Make `.nav-header__tabs` sticky.
- d635233 – `SwipeableViews` -> `bindKeyboard(SwipeableViews)`