### PR TITLE
feat(service): Pull and persist `Post.tags` per #76.

### DIFF
--- a/packages/js/src/lib/post.js
+++ b/packages/js/src/lib/post.js
@@ -1,5 +1,5 @@
 import {BlogPosting as SchemaBlogPosting} from "@randy.tarampi/schema-dot-org-types";
-import {Record} from "immutable";
+import {List, Record} from "immutable";
 import Profile from "./profile";
 import {augmentUrlWithTrackingParams, castDatePropertyToDateTime, compositeKeySeparator} from "./util";
 
@@ -14,6 +14,7 @@ export const PostClassGenerator = otherProperties => class AbstractPost extends 
     sourceUrl: null,
     creator: null,
     raw: null,
+    tags: List(),
     ...otherProperties
 }) {
     constructor({dateCreated, datePublished, ...properties} = {}) {
@@ -51,7 +52,8 @@ export const PostClassGenerator = otherProperties => class AbstractPost extends 
     static parsePropertiesFromJs(js) {
         return {
             ...js,
-            creator: js.creator ? Profile.fromJS(js.creator) : null
+            creator: js.creator ? Profile.fromJS(js.creator) : null,
+            tags: js.tags ? List(js.tags) : null
         };
     }
 
@@ -62,7 +64,8 @@ export const PostClassGenerator = otherProperties => class AbstractPost extends 
     static parsePropertiesFromJson(json) {
         return {
             ...json,
-            creator: json.creator ? Profile.fromJSON(json.creator) : null
+            creator: json.creator ? Profile.fromJSON(json.creator) : null,
+            tags: json.tags ? List(json.tags) : null
         };
     }
 

--- a/packages/js/test/unit/src/lib/post.js
+++ b/packages/js/test/unit/src/lib/post.js
@@ -1,4 +1,5 @@
 import {expect} from "chai";
+import {List} from "immutable";
 import {DateTime} from "luxon";
 import Post from "../../../../src/lib/post";
 import Profile from "../../../../src/lib/profile";
@@ -62,7 +63,12 @@ describe("Post", () => {
                     username: "ʕ•ᴥ•ʔ",
                     name: "ʕ•ᴥ•ʔ",
                     url: "woof://woof.woof/woof/woof/woof"
-                }
+                },
+                tags: [
+                    "woof",
+                    "meow",
+                    "grr"
+                ]
             };
 
             const postFromJson = Post.fromJSON(postJson);
@@ -70,6 +76,8 @@ describe("Post", () => {
             expect(postFromJson).to.be.ok;
             expect(postFromJson.id).to.eql(postJson.id);
             expect(postFromJson.dateCreated).to.be.instanceof(DateTime);
+            expect(postFromJson.tags).to.be.instanceof(List);
+            expect(postFromJson.tags.toJS()).to.eql(postJson.tags);
         });
     });
 

--- a/packages/service/src/db/schema/post.js
+++ b/packages/service/src/db/schema/post.js
@@ -74,6 +74,9 @@ const post = new Schema({
     raw: {
         type: Object,
         required: true
+    },
+    tags: {
+        type: [String]
     }
 }, {
     throughput,

--- a/packages/service/src/lib/searchParams.js
+++ b/packages/service/src/lib/searchParams.js
@@ -55,7 +55,7 @@ class SearchParams extends SearchParamsRecord {
         return {
             page: this.page,
             per_page: Math.min(this.perPage, 500),
-            extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description, tags"
+            extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description, tags, machine_tags"
         };
     }
 

--- a/packages/service/src/lib/searchParams.js
+++ b/packages/service/src/lib/searchParams.js
@@ -55,7 +55,7 @@ class SearchParams extends SearchParamsRecord {
         return {
             page: this.page,
             per_page: Math.min(this.perPage, 500),
-            extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description"
+            extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description, tags"
         };
     }
 

--- a/packages/service/src/lib/sources/flickr/index.js
+++ b/packages/service/src/lib/sources/flickr/index.js
@@ -53,7 +53,8 @@ class FlickrSource extends CachedDataSource {
                 id: json.owner,
                 username: json.ownername,
                 url: `https://www.flickr.com/${json.ownername}`
-            }
+            },
+            tags: json.tags ? json.tags.split(" ") : []
         });
     }
 

--- a/packages/service/src/lib/sources/instagram/index.js
+++ b/packages/service/src/lib/sources/instagram/index.js
@@ -58,7 +58,8 @@ class InstagramSource extends CachedDataSource {
                 name: photoJson.user.full_name,
                 url: `https://www.instagram.com/${photoJson.user.username}`,
                 image: photoJson.user.profile_picture
-            }
+            },
+            tags: photoJson.tags
         });
     }
 

--- a/packages/service/src/lib/sources/s3/index.js
+++ b/packages/service/src/lib/sources/s3/index.js
@@ -51,7 +51,8 @@ class S3Source extends CachedDataSource {
             source: S3Source.type,
             datePublished: postJson.date,
             title: postJson.title,
-            body: postJson.body
+            body: postJson.body,
+            tags: postJson.tags
         });
     }
 

--- a/packages/service/src/lib/sources/tumblr/index.js
+++ b/packages/service/src/lib/sources/tumblr/index.js
@@ -69,7 +69,8 @@ class TumblrSource extends CachedDataSource {
                 username: postJson.blog.name,
                 name: postJson.blog.title,
                 url: postJson.blog.url
-            }
+            },
+            tags: postJson.tags
         });
     }
 
@@ -92,7 +93,8 @@ class TumblrSource extends CachedDataSource {
                 username: postJson.blog.name,
                 name: postJson.blog.title,
                 url: postJson.blog.url
-            }
+            },
+            tags: postJson.tags
         });
     }
 

--- a/packages/service/test/unit/src/lib/searchParams.js
+++ b/packages/service/test/unit/src/lib/searchParams.js
@@ -36,7 +36,7 @@ describe("SearchParams", function () {
             expect(searchParams.Flickr).to.eql({
                 page: searchParams.page,
                 per_page: searchParams.perPage,
-                extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description, tags"
+                extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description, tags, machine_tags"
             });
         });
     });

--- a/packages/service/test/unit/src/lib/searchParams.js
+++ b/packages/service/test/unit/src/lib/searchParams.js
@@ -36,7 +36,7 @@ describe("SearchParams", function () {
             expect(searchParams.Flickr).to.eql({
                 page: searchParams.page,
                 per_page: searchParams.perPage,
-                extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description"
+                extras: "url_o, url_k, url_h, url_c, url_z, url_m, url_n, date_upload, date_taken, owner_name, path_alias, description, tags"
             });
         });
     });

--- a/packages/service/test/unit/src/lib/sources/flickr/index.js
+++ b/packages/service/test/unit/src/lib/sources/flickr/index.js
@@ -66,7 +66,8 @@ describe("FlickrSource", function () {
             title: "ʕ•ᴥ•ʔﾉ゛",
             description: {
                 _content: "<p>Woof woof woof</p>"
-            }
+            },
+            tags: "woof meow grr"
         };
         flickrPhotos = stubPosts.map(stubPost => Object.assign({}, flickrPhoto, {id: stubPost.id}));
         stubServiceClient = {


### PR DESCRIPTION
Per #76, persist `tags` information – just the server(less) side of the task.

Unfortunately we don't get tags from Unsplash, but I'll take this as a bit of a quick victory.

Meat
---
- d017847 – Add `Post.tags`.
- d2e5b46 – Pull tags from Flickr.
- 2fffdf6 – Pull tags from Instagram.
- ecb7aff – Pull tags from S3.
- cb733d8 – Pull tags from Tumblr.

Sides
---
- 06d7fb0 – Pull `machine_tags` from Flickr, which are a bit more rich in information. Don't do anything with them just yet, but have them around in the `Post.raw` response for later.