### PR TITLE
feat(js): `Post.tags` can override certain API returned values.

### DIFF
--- a/packages/js/src/lib/post.js
+++ b/packages/js/src/lib/post.js
@@ -9,6 +9,10 @@ import {
     convertLatLongToGeohash
 } from "./util";
 
+const overridableTagProperties = {
+    dateCreated: tagValue => castDatePropertyToDateTime(Number(tagValue))
+};
+
 export const PostClassGenerator = otherProperties => class AbstractPost extends Record({
     id: null,
     type: null,
@@ -27,6 +31,19 @@ export const PostClassGenerator = otherProperties => class AbstractPost extends 
     ...otherProperties
 }) {
     constructor({dateCreated, datePublished, ...properties} = {}) {
+        if (properties.tags) {
+            Object.keys(overridableTagProperties).forEach(overridableTagProperty => {
+                const overridingTagSentinel = `❕${overridableTagProperty}❔`;
+                const overridingTag = properties.tags.find(tag => tag.startsWith(overridingTagSentinel));
+
+                if (overridingTag) {
+                    const overridingTagValue = overridingTag.replace(overridingTagSentinel, "");
+
+                    properties[overridableTagProperty] = overridableTagProperties[overridableTagProperty](overridingTagValue);
+                }
+            });
+        }
+
         super({
             dateCreated: castDatePropertyToDateTime(dateCreated),
             datePublished: castDatePropertyToDateTime(datePublished),

--- a/packages/js/src/lib/post.js
+++ b/packages/js/src/lib/post.js
@@ -10,7 +10,10 @@ import {
 } from "./util";
 
 const overridableTagProperties = {
-    dateCreated: tagValue => castDatePropertyToDateTime(Number(tagValue))
+    dateCreated: tagValue => castDatePropertyToDateTime(Number(tagValue)),
+    lat: tagValue => Number(tagValue),
+    long: tagValue => Number(tagValue),
+    geohash: tagValue => tagValue
 };
 
 export const PostClassGenerator = otherProperties => class AbstractPost extends Record({

--- a/packages/js/src/lib/util/castDatePropertyToDateTime.js
+++ b/packages/js/src/lib/util/castDatePropertyToDateTime.js
@@ -2,7 +2,7 @@ import {DateTime} from "luxon";
 
 /**
  * @function Cast some representation of a `Date` to a `DateTime`
- * @param needsToBeCastToDateTimeOrNull {Character}
+ * @param needsToBeCastToDateTimeOrNull {string | number | Date | DateTime}
  * @returns {DateTime}
  */
 export const castDatePropertyToDateTime = needsToBeCastToDateTimeOrNull => {

--- a/packages/js/test/unit/src/lib/post.js
+++ b/packages/js/test/unit/src/lib/post.js
@@ -35,6 +35,45 @@ describe("Post", () => {
             expect(post.type).to.eql(Post.name);
             expect(post.dateCreated).to.be.an.instanceOf(DateTime);
             expect(post.datePublished).to.be.an.instanceOf(DateTime);
+            expect(post.dateCreated).to.eql(postJs.dateCreated);
+            expect(post.datePublished).to.eql(postJs.datePublished);
+        });
+
+        it("overrides dateCreated", function () {
+            const postJs = {
+                id: "woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: new Profile({
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }),
+                lat: 49.2845,
+                long: -123.1116,
+                tags: [
+                    "foo",
+                    `❕dateCreated❔${DateTime.utc().plus({years: 1}).valueOf()}`,
+                    `❕datePublished❔${DateTime.utc().plus({years: -1}).valueOf()}`
+                ]
+            };
+
+            const post = new Post(postJs);
+
+            expect(post.type).to.eql(Post.name);
+            expect(post.dateCreated).to.be.an.instanceOf(DateTime);
+            expect(post.datePublished).to.be.an.instanceOf(DateTime);
+            expect(postJs.tags[1]).to.have.string(post.dateCreated.valueOf().toString());
+            expect(post.datePublished).to.eql(postJs.datePublished);
         });
 
         it("returns an empty Post", function () {

--- a/packages/js/test/unit/src/lib/post.js
+++ b/packages/js/test/unit/src/lib/post.js
@@ -27,7 +27,8 @@ describe("Post", () => {
                     url: "woof://woof.woof/woof/woof/woof"
                 }),
                 lat: 49.2845,
-                long: -123.1116
+                long: -123.1116,
+                tags: []
             };
 
             const post = new Post(postJs);
@@ -74,6 +75,102 @@ describe("Post", () => {
             expect(post.datePublished).to.be.an.instanceOf(DateTime);
             expect(postJs.tags[1]).to.have.string(post.dateCreated.valueOf().toString());
             expect(post.datePublished).to.eql(postJs.datePublished);
+        });
+
+        it("overrides lat", function () {
+            const postJs = {
+                id: "woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: new Profile({
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }),
+                lat: 49.2845,
+                long: -123.1116,
+                tags: [
+                    `❕lat❔${-49.2845}`
+                ]
+            };
+
+            const post = new Post(postJs);
+
+            expect(post.type).to.eql(Post.name);
+            expect(postJs.tags[0]).to.have.string(post.lat.toString());
+            expect(post.long).to.eql(postJs.long);
+        });
+
+        it("overrides lat", function () {
+            const postJs = {
+                id: "woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: new Profile({
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }),
+                lat: 49.2845,
+                long: -123.1116,
+                tags: [
+                    `❕long❔${+123.1116}`
+                ]
+            };
+
+            const post = new Post(postJs);
+
+            expect(post.type).to.eql(Post.name);
+            expect(post.lat).to.eql(postJs.lat);
+            expect(postJs.tags[0]).to.have.string(post.long.toString());
+        });
+
+        it("overrides geohash", function () {
+            const postJs = {
+                id: "woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: new Profile({
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }),
+                tags: [
+                    "❕geohash❔c2b2qebz5b9w"
+                ]
+            };
+
+            const post = new Post(postJs);
+
+            expect(post.type).to.eql(Post.name);
+            expect(postJs.tags[0]).to.have.string(post.geohash.toString());
         });
 
         it("returns an empty Post", function () {


### PR DESCRIPTION
Starting with `dateCreated` per randytarampi/me.photos#13 and `lat`, `long` and `geohash`.

Seems better to do this here in the `Post` constructor than in the data layer.

Meat
---
- b863797 – Override `dateCreated` per randytarampi/me.photos#13.
- 546d793 – Allow overriding of `lat`, `long` and `geohash` while we're in here.
