### PR TITLE
feat(jsx): Better UX for `.xl` `Post`s and `Photo`s. (#131)

### DIFF
--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -28,6 +28,10 @@
             line-height: $blockLineHeight;
             margin-right: 4px;
         }
+
+        p {
+            margin-top: 0;
+        }
     }
 
     &-text {
@@ -75,6 +79,16 @@
 
 .row .col.post-metadata {
     padding: 0.75em;
+
+    @media #{$medium-and-up} {
+        padding-bottom: 0;
+    }
+}
+
+.row .col.post-content {
+    @media #{$medium-and-up} {
+        padding: 0.75em;
+    }
 }
 
 .dimensions-container--posts {

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -1,3 +1,17 @@
+.row .col.post-metadata {
+    padding: 0.75em;
+
+    @media #{$medium-and-up} {
+        padding-bottom: 0;
+    }
+}
+
+.row .col.post-content {
+    @media #{$medium-and-up} {
+        padding: 0.75em;
+    }
+}
+
 .post {
     @extend .z-depth-1;
     margin-bottom: 0;
@@ -48,12 +62,20 @@
     &-title {
         margin-top: 0;
         margin-bottom: 0;
-        overflow-wrap: break-word;
-        word-break: break-word;
     }
 
     &--photo {
         background-size: cover;
+
+        .post-content, .post-metadata {
+            background-size: cover;
+        }
+
+        & .col.post-content {
+            @media #{$medium-and-up} {
+                padding: 0;
+            }
+        }
     }
 
     &--words {
@@ -75,20 +97,6 @@
 
 .photo-text {
     @extend .post-text; // NOTE-RT: Legacy content hooked into this.
-}
-
-.row .col.post-metadata {
-    padding: 0.75em;
-
-    @media #{$medium-and-up} {
-        padding-bottom: 0;
-    }
-}
-
-.row .col.post-content {
-    @media #{$medium-and-up} {
-        padding: 0.75em;
-    }
 }
 
 .dimensions-container--posts {

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -35,6 +35,19 @@
         }
     }
 
+    &-body {
+        &__html {
+            ul {
+                @extend .row;
+
+                li {
+                    @extend .col;
+                    @extend .m6;
+                }
+            }
+        }
+    }
+
     &-html {
         box-decoration-break: clone;
 

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -57,7 +57,13 @@
         }
 
         p {
-            margin-top: 0;
+            &:first-of-type {
+                margin-top: 0.5rem;
+            }
+
+            & + p {
+                margin-top: 0;
+            }
         }
     }
 

--- a/packages/jsx/src/lib/components/photo.jsx
+++ b/packages/jsx/src/lib/components/photo.jsx
@@ -3,124 +3,83 @@ import SchemaJsonLdComponent from "@randy.tarampi/schema-dot-org-json-ld-compone
 import isHtml from "is-html";
 import {DateTime} from "luxon";
 import PropTypes from "prop-types";
-import React from "react";
+import React, {Fragment} from "react";
 import {Col, Row} from "react-materialize";
 import ProgressiveImage from "react-progressive-image";
+import {WINDOW_LARGE_BREAKPOINT, WINDOW_LARGE_PHOTO_SCALE} from "../util";
 import {CampaignLink} from "./link";
 import {PostComponent} from "./post";
 
 export class PhotoComponent extends PostComponent {
-    get width() {
-        return this.selected.width;
-    }
-
-    get height() {
-        return this.selected.height;
-    }
-
     get selected() {
         const targetWidth = window.devicePixelRatio ?
-            this.containerWidth * window.devicePixelRatio :
-            this.containerWidth;
+            this.props.containerWidth * window.devicePixelRatio :
+            this.props.containerWidth;
         return this.props.post.getSizedPhotoForDisplay(targetWidth);
     }
 
+    get scaledHeight() {
+        let scaledHeight = this.props.containerWidth * this.selected.height / this.selected.width;
+
+        if (window.innerWidth >= WINDOW_LARGE_BREAKPOINT) {
+            const photoElement = document.getElementById(this.props.post.uid);
+            scaledHeight = Math.max(scaledHeight * WINDOW_LARGE_PHOTO_SCALE, photoElement ? photoElement.querySelector(".post-metadata.l4").clientHeight : 0);
+        }
+
+        return scaledHeight;
+    }
+
     render() {
+        const {post, isLoading, source} = this.props;
+
         const rowClassName = ["post post--photo"];
 
-        if (this.props.isLoading) {
+        if (isLoading) {
             rowClassName.push("post--loading");
         }
 
         return <Row
             className={rowClassName.join(" ")}
-            id={this.props.post.uid}
-            style={{
-                backgroundImage: `url(${this.props.source})`,
-                height: this.scaledHeight
-            }}
+            id={post.uid}
         >
-            <SchemaJsonLdComponent markup={this.props.post.toSchema()}/>
+            <SchemaJsonLdComponent markup={post.toSchema()}/>
             <Col
                 className="post-metadata hide-on-med-and-up"
+                s={12}
+                style={{
+                    backgroundImage: `url(${source})`,
+                    height: this.scaledHeight
+                }}
             >
                 <h1 className="post-title">
                     <CampaignLink className="post-title__link"
-                                  href={this.props.post.sourceUrl}>{this.title}</CampaignLink>
+                                  href={post.sourceUrl}>{this.title}</CampaignLink>
                 </h1>
             </Col>
             <Col
-                className="post-metadata hide-on-small-and-down"
+                className="post-metadata hide-on-small-only hide-on-large-only"
+                m={12}
+                style={{
+                    backgroundImage: `url(${source})`,
+                    height: this.scaledHeight
+                }}
+            >
+                <PostMetadataContent post={post} title={this.title}/>
+            </Col>
+            <Col
+                className="post-metadata hide-on-med-and-down"
                 l={4}
             >
-                <h1 className="post-title">
-                    <CampaignLink className="post-title__link"
-                                  href={this.props.post.sourceUrl}>{this.title}</CampaignLink>
-                </h1>
-                {
-                    typeof this.props.post.body === "string" && this.props.post.body !== "" ?
-                        <div className="post-body">
-                            {
-                                isHtml(this.props.post.body)
-                                    ? <div className="post-body__html">
-                                        <div dangerouslySetInnerHTML={{__html: this.props.post.body}}/>
-                                    </div>
-                                    : <p>
-                                        <span className="post-body__text"
-                                              dangerouslySetInnerHTML={{__html: this.props.post.body}}/>
-                                    </p>
-                            }
-                        </div> :
-                        null
-                }
-                {
-                    Array.isArray(this.props.post.body) ?
-                        this.props.post.body.map((htmlString, index) => {
-                            return <div className="post-body"
-                                        key={`${this.props.post.id}:${this.props.post.type}:body:${index}`}>
-                                {
-                                    isHtml(htmlString)
-                                        ? <div className="post-body__html">
-                                            <div dangerouslySetInnerHTML={{__html: htmlString}}/>
-                                        </div>
-                                        : <p>
-                                            <span className="post-body__text"
-                                                  dangerouslySetInnerHTML={{__html: htmlString}}/>
-                                        </p>
-                                }
-                            </div>;
-                        }) :
-                        null
-                }
-                {
-                    this.props.post.datePublished ?
-                        <p className="post-date">
-                            <strong
-                                className="post-date__label post-date__label--published">Posted:</strong>
-                            <span
-                                className="post-date__date post-date__date--published">{this.props.post.datePublished.toLocaleString(DateTime.DATE_MED)}</span>
-                        </p> :
-                        null
-                }
-                {
-                    this.props.post.dateCreated && this.props.post.dateCreated.valueOf() !== this.props.post.datePublished.valueOf() ?
-                        <p className="post-date">
-                            <strong className="post-date__label post-date__label--created">Taken:</strong>
-                            <span
-                                className="post-date__date post-date__date--created">{this.props.post.dateCreated.toLocaleString(DateTime.DATETIME_MED)}</span>
-                        </p> :
-                        null
-                }
-                <p className="post-source">
-                    <CampaignLink className="post-source__link" href={this.props.post.sourceUrl}>View
-                        on {this.props.post.source}</CampaignLink>
-                    {
-                        this.props.post.creator ?
-                            <CampaignLink className="post-source__link"
-                                          href={this.props.post.creator.url}>{this.props.post.creator.username} on {this.props.post.source}</CampaignLink> :
-                            null
-                    }
-                </p>
+                <PostMetadataContent post={post} title={this.title}/>
+            </Col>
+            <Col
+                className="post-content hide-on-med-and-down"
+                l={8}
+                style={{
+                    backgroundImage: `url(${source})`,
+                    height: this.scaledHeight
+                }}
+            >
             </Col>
         </Row>;
     }
@@ -130,6 +89,82 @@ PhotoComponent.propTypes = {
     post: PropTypes.instanceOf(PhotoEntity).isRequired,
     source: PropTypes.string.isRequired,
     isLoading: PropTypes.bool.isRequired
+};
+
+export const PostMetadataContent = ({post, title}) => <Fragment>
+    <h1 className="post-title">
+        <CampaignLink className="post-title__link"
+                      href={post.sourceUrl}>{title}</CampaignLink>
+    </h1>
+    {
+        typeof post.body === "string" && post.body !== "" ?
+            <div className="post-body">
+                {
+                    isHtml(post.body)
+                        ? <div className="post-body__html">
+                            <div dangerouslySetInnerHTML={{__html: post.body}}/>
+                        </div>
+                        : <p>
+                                        <span className="post-body__text"
+                                              dangerouslySetInnerHTML={{__html: post.body}}/>
+                        </p>
+                }
+            </div> :
+            null
+    }
+    {
+        Array.isArray(post.body) ?
+            post.body.map((htmlString, index) => {
+                return <div className="post-body"
+                            key={`${post.id}:${post.type}:body:${index}`}>
+                    {
+                        isHtml(htmlString)
+                            ? <div className="post-body__html">
+                                <div dangerouslySetInnerHTML={{__html: htmlString}}/>
+                            </div>
+                            : <p>
+                                            <span className="post-body__text"
+                                                  dangerouslySetInnerHTML={{__html: htmlString}}/>
+                            </p>
+                    }
+                </div>;
+            }) :
+            null
+    }
+    {
+        post.datePublished ?
+            <p className="post-date">
+                <strong
+                    className="post-date__label post-date__label--published">Posted:</strong>
+                <span
+                    className="post-date__date post-date__date--published">{post.datePublished.toLocaleString(DateTime.DATE_MED)}</span>
+            </p> :
+            null
+    }
+    {
+        post.dateCreated && post.dateCreated.valueOf() !== post.datePublished.valueOf() ?
+            <p className="post-date">
+                <strong className="post-date__label post-date__label--created">Taken:</strong>
+                <span
+                    className="post-date__date post-date__date--created">{post.dateCreated.toLocaleString(DateTime.DATETIME_MED)}</span>
+            </p> :
+            null
+    }
+    <p className="post-source">
+        <CampaignLink className="post-source__link" href={post.sourceUrl}>View
+            on {post.source}</CampaignLink>
+        {
+            post.creator ?
+                <CampaignLink className="post-source__link"
+                              href={post.creator.url}>{post.creator.username} on {post.source}</CampaignLink> :
+                null
+        }
+    </p>
+</Fragment>;
+
+PostMetadataContent.propTypes = {
+    post: PropTypes.instanceOf(PhotoEntity).isRequired,
+    title: PropTypes.string.isRequired
 };
 
 export const ProgressiveImageWrappedPhotoComponent = props => {
@@ -148,7 +183,7 @@ export const ProgressiveImageWrappedPhotoComponent = props => {
 
 ProgressiveImageWrappedPhotoComponent.propTypes = {
     containerWidth: PropTypes.number.isRequired,
-    post: PropTypes.instanceOf(PhotoEntity).isRequired,
+    post: PropTypes.instanceOf(PhotoEntity).isRequired
 };
 
 export default ProgressiveImageWrappedPhotoComponent;

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -45,6 +45,7 @@ export class PostComponent extends Component {
             <Col
                 className="post-metadata"
                 s={12}
+                l={4}
             >
                 <h1 className="post-title">
                     {
@@ -68,6 +69,12 @@ export class PostComponent extends Component {
                         </p> :
                         null
                 }
+            </Col>
+            <Col
+                className="post-content"
+                s={12}
+                l={8}
+            >
                 {
                     typeof this.props.post.body === "string"
                         ? <div className="post-body">

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -9,19 +9,21 @@ import {CampaignLink} from "./link";
 
 export class PostComponent extends Component {
     get width() {
-        return this.containerWidth;
+        const postElement = document.getElementById(this.props.post.uid);
+        return postElement ? postElement.clientWidth : this.props.containerHeight;
     }
 
     get height() {
-        return this.containerHeight;
-    }
-
-    get containerWidth() {
-        return this.props.containerWidth;
+        const postElement = document.getElementById(this.props.post.uid);
+        return postElement ? postElement.clientHeight : this.props.containerWidth;
     }
 
     get containerHeight() {
         return this.props.containerHeight;
+    }
+
+    get containerWidth() {
+        return this.props.containerWidth;
     }
 
     get scaledHeight() {

--- a/packages/jsx/src/lib/components/posts.jsx
+++ b/packages/jsx/src/lib/components/posts.jsx
@@ -48,8 +48,12 @@ export class PostsComponent extends Component {
                     postsArray
                         ? postsArray.map(post => {
                             const Constructor = getComponentForType(post.type);
-                            return <Constructor key={post.uid} post={post} containerHeight={props.containerHeight}
-                                                containerWidth={props.containerWidth}/>;
+                            return <Constructor
+                                key={post.uid}
+                                post={post}
+                                containerHeight={props.containerHeight}
+                                containerWidth={props.containerWidth}
+                            />;
                         })
                         : <div/>
                 }

--- a/packages/jsx/src/lib/util/computePostHeight.js
+++ b/packages/jsx/src/lib/util/computePostHeight.js
@@ -1,6 +1,15 @@
+export const WINDOW_LARGE_BREAKPOINT = 992;
+export const WINDOW_LARGE_PHOTO_SCALE = 8 / 12;
+
 export const computePostHeight = containerWidth => post => {
     if (post.height && post.width) {
-        return containerWidth * post.height / post.width;
+        let scaledHeight = Math.round(containerWidth * post.height / post.width);
+
+        if (window.innerWidth >= WINDOW_LARGE_BREAKPOINT) {
+            scaledHeight = scaledHeight * WINDOW_LARGE_PHOTO_SCALE;
+        }
+
+        return scaledHeight;
     }
 
     if (typeof document !== "undefined" && document.getElementById(post.uid)) {

--- a/packages/jsx/test/unit/src/lib/components/photo.jsx
+++ b/packages/jsx/test/unit/src/lib/components/photo.jsx
@@ -2,7 +2,10 @@ import {Photo as PhotoEntity} from "@randy.tarampi/js";
 import {expect} from "chai";
 import {shallow} from "enzyme";
 import React from "react";
-import ProgressiveImageWrappedPhotoComponent, {PhotoComponent} from "../../../../../src/lib/components/photo";
+import ProgressiveImageWrappedPhotoComponent, {
+    PhotoComponent,
+    PostMetadataContent
+} from "../../../../../src/lib/components/photo";
 
 describe("Photo", function () {
     let stubPhoto;
@@ -133,7 +136,9 @@ describe("Photo", function () {
             expect(rendered).to.have.className("post--photo");
             expect(rendered).to.have.className("post--loading");
 
-            const links = rendered.find(".post-source__link");
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+            const links = renderedMetadata.find(".post-source__link");
             expect(links).to.have.length(2);
             expect(links.first()).to.have.prop("href", stubPhoto.sourceUrl);
             expect(links.last()).to.have.prop("href", stubPhoto.creator.url);
@@ -179,16 +184,21 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
+            expect(rendered).to.have.descendants(".post-metadata");
+            expect(rendered).to.have.descendants(".post-content");
 
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.not.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.not.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > p > .post-body__text");
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.not.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.not.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > p > .post-body__text");
         });
 
         it("renders (no body)", function () {
@@ -226,15 +236,20 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
+            expect(rendered).to.have.descendants(".post-metadata");
+            expect(rendered).to.have.descendants(".post-content");
 
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.not.have.descendants(".post-body");
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.not.have.descendants(".post-body");
         });
 
         it("renders (plain string body)", function () {
@@ -273,17 +288,21 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
-
             expect(rendered).to.have.descendants(".post-metadata");
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > p > .post-body__text");
+            expect(rendered).to.have.descendants(".post-content");
+
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > p > .post-body__text");
         });
 
         it("renders (html string body)", function () {
@@ -322,17 +341,20 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
-
             expect(rendered).to.have.descendants(".post-metadata");
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > div");
+            expect(rendered).to.have.descendants(".post-content");
+
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > div");
         });
 
         it("renders (array body)", function () {
@@ -375,89 +397,22 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
-
             expect(rendered).to.have.descendants(".post-metadata");
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > div");
-            expect(rendered).to.have.descendants(".post-body > p > .post-body__text");
-        });
+            expect(rendered).to.have.descendants(".post-content");
 
-        describe("#width", function () {
-            it("returns the `selected.width`", function () {
-                stubPhoto = PhotoEntity.fromJSON({
-                    id: "woof",
-                    type: "Woof",
-                    source: "Woofdy",
-                    dateCreated: new Date(1900, 0, 1).toISOString(),
-                    datePublished: new Date(2500, 0, 1).toISOString(),
-                    width: -1,
-                    height: -2,
-                    sizedPhotos: [
-                        {url: "woof://woof.woof/woof/woofto", width: 640, height: 480},
-                        {url: "woof://woof.woof/woof/woofto?w=800", width: 800}
-                    ],
-                    title: "Woof woof woof",
-                    body: [
-                        "ʕ•ᴥ•ʔ",
-                        "<span class=\"Woof\">ʕ•ᴥ•ʔ</span>",
-                        "ʕ◠ᴥ◠ʔ"
-                    ],
-                    sourceUrl: "woof://woof.woof/woof",
-                    creator: {
-                        id: -1,
-                        username: "ʕ•ᴥ•ʔ",
-                        name: "ʕ•ᴥ•ʔ",
-                        url: "woof://woof.woof/woof/woof/woof"
-                    }
-                });
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
 
-                const stubProps = {
-                    post: stubPhoto,
-                    containerHeight: 123,
-                    containerWidth: 123,
-                    isLoading: false,
-                    source: stubPhoto.getSizedPhotoForLoading().url
-                };
-                const rendered = shallow(<PhotoComponent {...stubProps}/>);
-
-                expect(rendered).to.be.ok;
-                expect(rendered).to.have.id(stubProps.post.uid);
-                expect(rendered).to.have.className("post--photo");
-
-                const component = rendered.instance();
-                expect(component).to.be.ok;
-                expect(component.width).to.be.ok;
-                expect(component.width).to.eql(component.selected.width);
-            });
-        });
-
-        describe("#height", function () {
-            it("returns the `selected.height`", function () {
-                const stubProps = {
-                    post: stubPhoto,
-                    containerHeight: 123,
-                    containerWidth: 123,
-                    isLoading: false,
-                    source: stubPhoto.getSizedPhotoForLoading().url
-                };
-                const rendered = shallow(<PhotoComponent {...stubProps}/>);
-
-                expect(rendered).to.be.ok;
-                expect(rendered).to.have.id(stubProps.post.uid);
-                expect(rendered).to.have.className("post--photo");
-
-                const component = rendered.instance();
-                expect(component).to.be.ok;
-                expect(component.height).to.be.ok;
-                expect(component.height).to.eql(component.selected.height);
-            });
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > div");
+            expect(renderedMetadata).to.have.descendants(".post-body > p > .post-body__text");
         });
 
         describe("#selected", function () {

--- a/packages/jsx/test/unit/src/lib/util/computePostHeight.js
+++ b/packages/jsx/test/unit/src/lib/util/computePostHeight.js
@@ -1,7 +1,7 @@
 import {Photo} from "@randy.tarampi/js";
 import {expect} from "chai";
 import {JSDOM} from "jsdom";
-import computePostHeight from "../../../../../src/lib/util/computePostHeight";
+import computePostHeight, {WINDOW_LARGE_PHOTO_SCALE} from "../../../../../src/lib/util/computePostHeight";
 
 describe("computePostHeight", function () {
     const globalWindow = global.window;
@@ -18,7 +18,7 @@ describe("computePostHeight", function () {
         const computedPostHeight = computePostHeight(stubContainerWidth)(stubPost);
 
         expect(computedPostHeight).to.be.ok;
-        expect(computedPostHeight).to.eql(500); // NOTE-RT: 500 * 1000 / 1000
+        expect(computedPostHeight).to.eql(500 * WINDOW_LARGE_PHOTO_SCALE); // NOTE-RT: 500 * 1000 / 1000 * WINDOW_LARGE_PHOTO_SCALE
     });
 
     // NOTE-RT: I really don't know when we'd be falling into here. I think that might just be me requiring coffee though...


### PR DESCRIPTION
Pull the `.post-metadata` content out to the right hand side on `medium-and-up` screens. A little bit gross with how I'm defining constants in JS based off the CSS, but y'know, gotta ship things.

Resolves #131, or at least it should after #76, randytarampi/me.photos#6 and randytarampi/me.photos#7 are taken care of.

Meat
---
- 4ef4b28  – Better UX for `.xl` `Post`s.
- 5f212d1 – Better UX for `.xl` `Photo`s.

Sides
---
- e6db41c – Tighter whitespace on `.post-title + .post-html p`.

Dessert
---
- 371b138 – `.post-body ul > li` on `medium-and-up` screens take up half the space (6 columns)
