### PR TITLE
feat(jsx): Better support `.xl` screens and do something with `tags`.

### DIFF
--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -28,6 +28,10 @@
             line-height: $blockLineHeight;
             margin-right: 4px;
         }
+
+        p {
+            margin-top: 0;
+        }
     }
 
     &-text {
@@ -75,6 +79,16 @@
 
 .row .col.post-metadata {
     padding: 0.75em;
+
+    @media #{$medium-and-up} {
+        padding-bottom: 0;
+    }
+}
+
+.row .col.post-content {
+    @media #{$medium-and-up} {
+        padding: 0.75em;
+    }
 }
 
 .dimensions-container--posts {

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -50,6 +50,7 @@
                 li {
                     @extend .col;
                     @extend .m6;
+                    @extend .s12;
                 }
             }
         }

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -20,7 +20,8 @@
     &-description,
     &-date,
     &-body,
-    &-source {
+    &-source,
+    &-tags {
         &__html {
             @extend .post-html;
         }
@@ -32,6 +33,12 @@
         &__link {
             text-decoration: underline;
             text-decoration-color: $link-color;
+        }
+
+        &__tag {
+            @extend .post-text;
+
+            line-height: 2 !important;
         }
     }
 

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -1,5 +1,5 @@
 .row .col.post-metadata {
-    padding: 0.75rem 0.75rem 0 0.75rem;
+    padding: 0.75rem 0.75rem 0;
 }
 
 .row .col.post-content {

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -1,3 +1,17 @@
+.row .col.post-metadata {
+    padding: 0.75em;
+
+    @media #{$medium-and-up} {
+        padding-bottom: 0;
+    }
+}
+
+.row .col.post-content {
+    @media #{$medium-and-up} {
+        padding: 0.75em;
+    }
+}
+
 .post {
     @extend .z-depth-1;
     margin-bottom: 0;
@@ -48,12 +62,20 @@
     &-title {
         margin-top: 0;
         margin-bottom: 0;
-        overflow-wrap: break-word;
-        word-break: break-word;
     }
 
     &--photo {
         background-size: cover;
+
+        .post-content, .post-metadata {
+            background-size: cover;
+        }
+
+        & .col.post-content {
+            @media #{$medium-and-up} {
+                padding: 0;
+            }
+        }
     }
 
     &--words {
@@ -75,20 +97,6 @@
 
 .photo-text {
     @extend .post-text; // NOTE-RT: Legacy content hooked into this.
-}
-
-.row .col.post-metadata {
-    padding: 0.75em;
-
-    @media #{$medium-and-up} {
-        padding-bottom: 0;
-    }
-}
-
-.row .col.post-content {
-    @media #{$medium-and-up} {
-        padding: 0.75em;
-    }
 }
 
 .dimensions-container--posts {

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -1,14 +1,10 @@
 .row .col.post-metadata {
-    padding: 0.75em;
-
-    @media #{$medium-and-up} {
-        padding-bottom: 0;
-    }
+    padding: 0.75rem 0.75rem 0 0.75rem;
 }
 
 .row .col.post-content {
     @media #{$medium-and-up} {
-        padding: 0.75em;
+        padding: 0.75rem;
     }
 }
 
@@ -26,18 +22,20 @@
             @extend .post-html;
         }
 
-        &__link, &__text, &__label, &__date {
+        &__link, &__text, &__label, &__date, &__tag {
             @extend .post-text;
         }
 
-        &__link {
+        &__link, &__tag {
             text-decoration: underline;
             text-decoration-color: $link-color;
         }
+    }
 
-        &__tag {
-            @extend .post-text;
-
+    &-source,
+    &-date,
+    &-tags {
+        &__link, &__text, &__label, &__date, &__tag {
             line-height: 2 !important;
         }
     }

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -35,6 +35,19 @@
         }
     }
 
+    &-body {
+        &__html {
+            ul {
+                @extend .row;
+
+                li {
+                    @extend .col;
+                    @extend .m6;
+                }
+            }
+        }
+    }
+
     &-html {
         box-decoration-break: clone;
 

--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -57,7 +57,13 @@
         }
 
         p {
-            margin-top: 0;
+            &:first-of-type {
+                margin-top: 0.5rem;
+            }
+
+            & + p {
+                margin-top: 0;
+            }
         }
     }
 

--- a/packages/jsx/src/lib/actions/fetchPosts.js
+++ b/packages/jsx/src/lib/actions/fetchPosts.js
@@ -10,9 +10,9 @@ export const FETCHING_POSTS_SUCCESS = "FETCHING_POSTS_SUCCESS";
 export const FETCHING_POSTS_CANCELLED = "FETCHING_POSTS_CANCELLED";
 export const FETCHING_POSTS = "FETCHING_POSTS";
 
-export const FETCHING_POSTS_PER_PAGE = 4;
+export const FETCHING_POSTS_PER_PAGE = 8;
 
-export const fetchPostsCreator = (fetchUrl, type = "global") => (dispatch, getState) => {
+export const fetchPostsCreator = (fetchUrl, type = "global", {params: {filter, filterValue} = {}} = {}) => (dispatch, getState) => {
     const state = getState();
     const urlState = selectors.getApiStateForUrl(state, fetchUrl);
     const isLoading = isUrlStateLoading(urlState);
@@ -29,18 +29,8 @@ export const fetchPostsCreator = (fetchUrl, type = "global") => (dispatch, getSt
     const oldestLoadedPostDate = oldestLoadedPost && oldestLoadedPost.datePublished;
     const oldestPostAvailableDate = selectors.getPostsState(state).getIn(["oldest", type]);
 
-    if (oldestPostAvailableDate && oldestLoadedPostDate && oldestLoadedPostDate.diff(oldestPostAvailableDate) <= 0) {
-        dispatch(fetchingPostsCancelled({
-            fetchUrl,
-            oldestPostAvailableDate,
-            oldestLoadedPostDate
-        }));
-        return Promise.resolve();
-    }
-
     const searchParams = {
         perPage: FETCHING_POSTS_PER_PAGE,
-        type: type !== "global" && type || undefined,
         ...(
             oldestLoadedPostDate
                 ? {
@@ -53,14 +43,33 @@ export const fetchPostsCreator = (fetchUrl, type = "global") => (dispatch, getSt
         )
     };
 
+    if (type && type !== "global") {
+        searchParams.type = type;
+    }
+
+    if (filter) {
+        searchParams[filter] = filterValue;
+    }
+
+    if (oldestPostAvailableDate && oldestLoadedPostDate && oldestLoadedPostDate.diff(oldestPostAvailableDate) <= 0) {
+        dispatch(fetchingPostsCancelled({
+            searchParams,
+            fetchUrl,
+            oldestPostAvailableDate,
+            oldestLoadedPostDate
+        }));
+        return Promise.resolve();
+    }
+
     dispatch(fetchingPosts({
-        fetchUrl,
-        searchParams
+        searchParams,
+        fetchUrl
     }));
 
     return fetchPosts(fetchUrl, searchParams)
         .then(postsResponse => {
             dispatch(fetchingPostsSuccess({
+                searchParams,
                 fetchUrl,
                 ...postsResponse
             }));
@@ -71,6 +80,7 @@ export const fetchPostsCreator = (fetchUrl, type = "global") => (dispatch, getSt
         })
         .catch(error => {
             dispatch(fetchingPostsFailure({
+                searchParams,
                 fetchUrl,
                 error
             }));
@@ -79,6 +89,7 @@ export const fetchPostsCreator = (fetchUrl, type = "global") => (dispatch, getSt
                 dispatch(setError(error, "EFETCH"));
             } else {
                 dispatch(fetchingPostsFailureRecovery({
+                    searchParams,
                     fetchUrl,
                     oldestPostAvailableDate,
                     oldestLoadedPostDate

--- a/packages/jsx/src/lib/actions/fetchPosts.js
+++ b/packages/jsx/src/lib/actions/fetchPosts.js
@@ -40,8 +40,9 @@ export const fetchPostsCreator = (fetchUrl, type = "global") => (dispatch, getSt
 
     const searchParams = {
         perPage: FETCHING_POSTS_PER_PAGE,
+        type: type !== "global" && type || undefined,
         ...(
-            oldestLoadedPostDate && (type === "global" || oldestLoadedPost.type === type)
+            oldestLoadedPostDate
                 ? {
                     orderBy: "datePublished",
                     orderOperator: "lt",

--- a/packages/jsx/src/lib/components/photo.jsx
+++ b/packages/jsx/src/lib/components/photo.jsx
@@ -7,7 +7,7 @@ import React, {Fragment} from "react";
 import {Col, Row} from "react-materialize";
 import ProgressiveImage from "react-progressive-image";
 import {WINDOW_LARGE_BREAKPOINT, WINDOW_LARGE_PHOTO_SCALE} from "../util";
-import {CampaignLink} from "./link";
+import {CampaignLink, InternalLink} from "./link";
 import {PostComponent} from "./post";
 
 export class PhotoComponent extends PostComponent {
@@ -30,7 +30,7 @@ export class PhotoComponent extends PostComponent {
     }
 
     render() {
-        const {post, isLoading, source} = this.props;
+        const {post, isLoading, source, placeholder} = this.props;
 
         const rowClassName = ["post post--photo"];
 
@@ -41,6 +41,9 @@ export class PhotoComponent extends PostComponent {
         return <Row
             className={rowClassName.join(" ")}
             id={post.uid}
+            style={{
+                backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="display:none"><defs><filter id="filter-blur-1"> <feGaussianBlur stdDeviation="5"/></filter></defs></svg>'), linear-gradient(to top right, rgba(0,0,0,0.67), rgba(0,0,0,0.33)), url(${placeholder})`
+            }}
         >
             <SchemaJsonLdComponent markup={post.toSchema()}/>
             <Col
@@ -87,6 +90,7 @@ export class PhotoComponent extends PostComponent {
 
 PhotoComponent.propTypes = {
     post: PropTypes.instanceOf(PhotoEntity).isRequired,
+    placeholder: PropTypes.string.isRequired,
     source: PropTypes.string.isRequired,
     isLoading: PropTypes.bool.isRequired
 };
@@ -132,14 +136,23 @@ export const PostMetadataContent = ({post, title}) => <Fragment>
             null
     }
     {
-        post.datePublished ?
-            <p className="post-date">
-                <strong
-                    className="post-date__label post-date__label--published">Posted:</strong>
-                <span
-                    className="post-date__date post-date__date--published">{post.datePublished.toLocaleString(DateTime.DATE_MED)}</span>
-            </p> :
-            null
+        post.datePublished
+            ? <Fragment>
+                <p className="post-date">
+                    <strong
+                        className="post-date__label post-date__label--published">Posted:</strong>
+                    <span
+                        className="post-date__date post-date__date--published">{post.datePublished.toLocaleString(DateTime.DATE_MED)}</span>
+                    {
+                        post.creator ?
+                            <CampaignLink className="post-source__link"
+                                          href={post.creator.url}>{post.creator.username} on {post.source}</CampaignLink>
+
+                            : null
+                    }
+                </p>
+            </Fragment>
+            : null
     }
     {
         post.dateCreated && post.dateCreated.valueOf() !== post.datePublished.valueOf() ?
@@ -150,23 +163,13 @@ export const PostMetadataContent = ({post, title}) => <Fragment>
             </p> :
             null
     }
-    <p className="post-source">
-        <CampaignLink className="post-source__link" href={post.sourceUrl}>View
-            on {post.source}</CampaignLink>
-        {
-            post.creator ?
-                <CampaignLink className="post-source__link"
-                              href={post.creator.url}>{post.creator.username} on {post.source}</CampaignLink> :
-                null
-        }
-    </p>
     {
         post.tags && post.tags.size
-            ? <p className="post-tags">
+            ? <p className="post-tags hide-on-med-and-down">
                 <strong className="post-tags__label">Tags:</strong>
                 {
-                    post.tags.map(tag => <Fragment key={tag}>
-                        <span className="post-tags__tag">{tag}</span>&ensp;
+                    post.tags.map(tag => <Fragment key={tag}><InternalLink className="post-tags__tag"
+                                                                           href={`${__POSTS_APP_URL__}/tags/${tag}`}>{tag}</InternalLink>
                     </Fragment>)
                 }
             </p>
@@ -176,6 +179,7 @@ export const PostMetadataContent = ({post, title}) => <Fragment>
 
 PostMetadataContent.propTypes = {
     post: PropTypes.instanceOf(PhotoEntity).isRequired,
+    placeholder: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
 };
 
@@ -188,7 +192,8 @@ export const ProgressiveImageWrappedPhotoComponent = props => {
 
     return <ProgressiveImage src={selected.url} placeholder={placeholder.url}>
         {
-            (source, isLoading) => <PhotoComponent {...props} source={source} isLoading={isLoading}/>
+            (source, isLoading) => <PhotoComponent {...props} placeholder={placeholder.url} source={source}
+                                                   isLoading={isLoading}/>
         }
     </ProgressiveImage>;
 };

--- a/packages/jsx/src/lib/components/photo.jsx
+++ b/packages/jsx/src/lib/components/photo.jsx
@@ -160,6 +160,18 @@ export const PostMetadataContent = ({post, title}) => <Fragment>
                 null
         }
     </p>
+    {
+        post.tags && post.tags.size
+            ? <p className="post-tags">
+                <strong className="post-tags__label">Tags:</strong>
+                {
+                    post.tags.map(tag => <Fragment key={tag}>
+                        <span className="post-tags__tag">{tag}</span>&ensp;
+                    </Fragment>)
+                }
+            </p>
+            : null
+    }
 </Fragment>;
 
 PostMetadataContent.propTypes = {

--- a/packages/jsx/src/lib/components/photo.jsx
+++ b/packages/jsx/src/lib/components/photo.jsx
@@ -168,9 +168,14 @@ export const PostMetadataContent = ({post, title}) => <Fragment>
             ? <p className="post-tags hide-on-med-and-down">
                 <strong className="post-tags__label">Tags:</strong>
                 {
-                    post.tags.map(tag => <Fragment key={tag}><InternalLink className="post-tags__tag"
-                                                                           href={`${__POSTS_APP_URL__}/tags/${tag}`}>{tag}</InternalLink>
-                    </Fragment>)
+                    post.tags.map(
+                        tag => <Fragment key={tag}><InternalLink
+                            className="post-tags__tag"
+                            href={`${__POSTS_APP_URL__}/tags/${tag}`}
+                        >
+                            {tag}
+                        </InternalLink> </Fragment> // NOTE-RT: We need this ` ` between the `</InternalLink>` and the `</Fragment>` because Safari (Webkit?) seems to collapse `&#0032;` and not insert line breaks between each `<Fragment>` but doesn't with ` `
+                    )
                 }
             </p>
             : null

--- a/packages/jsx/src/lib/components/photo.jsx
+++ b/packages/jsx/src/lib/components/photo.jsx
@@ -3,124 +3,83 @@ import SchemaJsonLdComponent from "@randy.tarampi/schema-dot-org-json-ld-compone
 import isHtml from "is-html";
 import {DateTime} from "luxon";
 import PropTypes from "prop-types";
-import React from "react";
+import React, {Fragment} from "react";
 import {Col, Row} from "react-materialize";
 import ProgressiveImage from "react-progressive-image";
+import {WINDOW_LARGE_BREAKPOINT, WINDOW_LARGE_PHOTO_SCALE} from "../util";
 import {CampaignLink} from "./link";
 import {PostComponent} from "./post";
 
 export class PhotoComponent extends PostComponent {
-    get width() {
-        return this.selected.width;
-    }
-
-    get height() {
-        return this.selected.height;
-    }
-
     get selected() {
         const targetWidth = window.devicePixelRatio ?
-            this.containerWidth * window.devicePixelRatio :
-            this.containerWidth;
+            this.props.containerWidth * window.devicePixelRatio :
+            this.props.containerWidth;
         return this.props.post.getSizedPhotoForDisplay(targetWidth);
     }
 
+    get scaledHeight() {
+        let scaledHeight = this.props.containerWidth * this.selected.height / this.selected.width;
+
+        if (window.innerWidth >= WINDOW_LARGE_BREAKPOINT) {
+            const photoElement = document.getElementById(this.props.post.uid);
+            scaledHeight = Math.max(scaledHeight * WINDOW_LARGE_PHOTO_SCALE, photoElement ? photoElement.querySelector(".post-metadata.l4").clientHeight : 0);
+        }
+
+        return scaledHeight;
+    }
+
     render() {
+        const {post, isLoading, source} = this.props;
+
         const rowClassName = ["post post--photo"];
 
-        if (this.props.isLoading) {
+        if (isLoading) {
             rowClassName.push("post--loading");
         }
 
         return <Row
             className={rowClassName.join(" ")}
-            id={this.props.post.uid}
-            style={{
-                backgroundImage: `url(${this.props.source})`,
-                height: this.scaledHeight
-            }}
+            id={post.uid}
         >
-            <SchemaJsonLdComponent markup={this.props.post.toSchema()}/>
+            <SchemaJsonLdComponent markup={post.toSchema()}/>
             <Col
                 className="post-metadata hide-on-med-and-up"
+                s={12}
+                style={{
+                    backgroundImage: `url(${source})`,
+                    height: this.scaledHeight
+                }}
             >
                 <h1 className="post-title">
                     <CampaignLink className="post-title__link"
-                                  href={this.props.post.sourceUrl}>{this.title}</CampaignLink>
+                                  href={post.sourceUrl}>{this.title}</CampaignLink>
                 </h1>
             </Col>
             <Col
-                className="post-metadata hide-on-small-and-down"
+                className="post-metadata hide-on-small-only hide-on-large-only"
+                m={12}
+                style={{
+                    backgroundImage: `url(${source})`,
+                    height: this.scaledHeight
+                }}
+            >
+                <PostMetadataContent post={post} title={this.title}/>
+            </Col>
+            <Col
+                className="post-metadata hide-on-med-and-down"
                 l={4}
             >
-                <h1 className="post-title">
-                    <CampaignLink className="post-title__link"
-                                  href={this.props.post.sourceUrl}>{this.title}</CampaignLink>
-                </h1>
-                {
-                    typeof this.props.post.body === "string" && this.props.post.body !== "" ?
-                        <div className="post-body">
-                            {
-                                isHtml(this.props.post.body)
-                                    ? <div className="post-body__html">
-                                        <div dangerouslySetInnerHTML={{__html: this.props.post.body}}/>
-                                    </div>
-                                    : <p>
-                                        <span className="post-body__text"
-                                              dangerouslySetInnerHTML={{__html: this.props.post.body}}/>
-                                    </p>
-                            }
-                        </div> :
-                        null
-                }
-                {
-                    Array.isArray(this.props.post.body) ?
-                        this.props.post.body.map((htmlString, index) => {
-                            return <div className="post-body"
-                                        key={`${this.props.post.id}:${this.props.post.type}:body:${index}`}>
-                                {
-                                    isHtml(htmlString)
-                                        ? <div className="post-body__html">
-                                            <div dangerouslySetInnerHTML={{__html: htmlString}}/>
-                                        </div>
-                                        : <p>
-                                            <span className="post-body__text"
-                                                  dangerouslySetInnerHTML={{__html: htmlString}}/>
-                                        </p>
-                                }
-                            </div>;
-                        }) :
-                        null
-                }
-                {
-                    this.props.post.datePublished ?
-                        <p className="post-date">
-                            <strong
-                                className="post-date__label post-date__label--published">Posted:</strong>
-                            <span
-                                className="post-date__date post-date__date--published">{this.props.post.datePublished.toLocaleString(DateTime.DATE_MED)}</span>
-                        </p> :
-                        null
-                }
-                {
-                    this.props.post.dateCreated && this.props.post.dateCreated.valueOf() !== this.props.post.datePublished.valueOf() ?
-                        <p className="post-date">
-                            <strong className="post-date__label post-date__label--created">Taken:</strong>
-                            <span
-                                className="post-date__date post-date__date--created">{this.props.post.dateCreated.toLocaleString(DateTime.DATETIME_MED)}</span>
-                        </p> :
-                        null
-                }
-                <p className="post-source">
-                    <CampaignLink className="post-source__link" href={this.props.post.sourceUrl}>View
-                        on {this.props.post.source}</CampaignLink>
-                    {
-                        this.props.post.creator ?
-                            <CampaignLink className="post-source__link"
-                                          href={this.props.post.creator.url}>{this.props.post.creator.username} on {this.props.post.source}</CampaignLink> :
-                            null
-                    }
-                </p>
+                <PostMetadataContent post={post} title={this.title}/>
+            </Col>
+            <Col
+                className="post-content hide-on-med-and-down"
+                l={8}
+                style={{
+                    backgroundImage: `url(${source})`,
+                    height: this.scaledHeight
+                }}
+            >
             </Col>
         </Row>;
     }
@@ -130,6 +89,82 @@ PhotoComponent.propTypes = {
     post: PropTypes.instanceOf(PhotoEntity).isRequired,
     source: PropTypes.string.isRequired,
     isLoading: PropTypes.bool.isRequired
+};
+
+export const PostMetadataContent = ({post, title}) => <Fragment>
+    <h1 className="post-title">
+        <CampaignLink className="post-title__link"
+                      href={post.sourceUrl}>{title}</CampaignLink>
+    </h1>
+    {
+        typeof post.body === "string" && post.body !== "" ?
+            <div className="post-body">
+                {
+                    isHtml(post.body)
+                        ? <div className="post-body__html">
+                            <div dangerouslySetInnerHTML={{__html: post.body}}/>
+                        </div>
+                        : <p>
+                                        <span className="post-body__text"
+                                              dangerouslySetInnerHTML={{__html: post.body}}/>
+                        </p>
+                }
+            </div> :
+            null
+    }
+    {
+        Array.isArray(post.body) ?
+            post.body.map((htmlString, index) => {
+                return <div className="post-body"
+                            key={`${post.id}:${post.type}:body:${index}`}>
+                    {
+                        isHtml(htmlString)
+                            ? <div className="post-body__html">
+                                <div dangerouslySetInnerHTML={{__html: htmlString}}/>
+                            </div>
+                            : <p>
+                                            <span className="post-body__text"
+                                                  dangerouslySetInnerHTML={{__html: htmlString}}/>
+                            </p>
+                    }
+                </div>;
+            }) :
+            null
+    }
+    {
+        post.datePublished ?
+            <p className="post-date">
+                <strong
+                    className="post-date__label post-date__label--published">Posted:</strong>
+                <span
+                    className="post-date__date post-date__date--published">{post.datePublished.toLocaleString(DateTime.DATE_MED)}</span>
+            </p> :
+            null
+    }
+    {
+        post.dateCreated && post.dateCreated.valueOf() !== post.datePublished.valueOf() ?
+            <p className="post-date">
+                <strong className="post-date__label post-date__label--created">Taken:</strong>
+                <span
+                    className="post-date__date post-date__date--created">{post.dateCreated.toLocaleString(DateTime.DATETIME_MED)}</span>
+            </p> :
+            null
+    }
+    <p className="post-source">
+        <CampaignLink className="post-source__link" href={post.sourceUrl}>View
+            on {post.source}</CampaignLink>
+        {
+            post.creator ?
+                <CampaignLink className="post-source__link"
+                              href={post.creator.url}>{post.creator.username} on {post.source}</CampaignLink> :
+                null
+        }
+    </p>
+</Fragment>;
+
+PostMetadataContent.propTypes = {
+    post: PropTypes.instanceOf(PhotoEntity).isRequired,
+    title: PropTypes.string.isRequired
 };
 
 export const ProgressiveImageWrappedPhotoComponent = props => {
@@ -148,7 +183,7 @@ export const ProgressiveImageWrappedPhotoComponent = props => {
 
 ProgressiveImageWrappedPhotoComponent.propTypes = {
     containerWidth: PropTypes.number.isRequired,
-    post: PropTypes.instanceOf(PhotoEntity).isRequired,
+    post: PropTypes.instanceOf(PhotoEntity).isRequired
 };
 
 export default ProgressiveImageWrappedPhotoComponent;

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -45,6 +45,7 @@ export class PostComponent extends Component {
             <Col
                 className="post-metadata"
                 s={12}
+                l={4}
             >
                 <h1 className="post-title">
                     {
@@ -68,6 +69,12 @@ export class PostComponent extends Component {
                         </p> :
                         null
                 }
+            </Col>
+            <Col
+                className="post-content"
+                s={12}
+                l={8}
+            >
                 {
                     typeof this.props.post.body === "string"
                         ? <div className="post-body">

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -5,7 +5,7 @@ import {DateTime} from "luxon";
 import PropTypes from "prop-types";
 import React, {Component, Fragment} from "react";
 import {Col, Row} from "react-materialize";
-import {CampaignLink} from "./link";
+import {CampaignLink, InternalLink} from "./link";
 
 export class PostComponent extends Component {
     get width() {
@@ -75,11 +75,11 @@ export class PostComponent extends Component {
                 }
                 {
                     post.tags && post.tags.size
-                        ? <p className="post-tags">
+                        ? <p className="post-tags hide-on-med-and-down">
                             <strong className="post-tags__label">Tags:</strong>
                             {
-                                post.tags.map(tag => <Fragment key={tag}>
-                                    <span className="post-tags__tag">{tag}</span>&ensp;
+                                post.tags.map(tag => <Fragment key={tag}><InternalLink className="post-tags__tag"
+                                                                                       href={`${__POSTS_APP_URL__}/tags/${tag}`}>{tag}</InternalLink>
                                 </Fragment>)
                             }
                         </p>

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -3,7 +3,7 @@ import SchemaJsonLdComponent from "@randy.tarampi/schema-dot-org-json-ld-compone
 import isHtml from "is-html";
 import {DateTime} from "luxon";
 import PropTypes from "prop-types";
-import React, {Component} from "react";
+import React, {Component, Fragment} from "react";
 import {Col, Row} from "react-materialize";
 import {CampaignLink} from "./link";
 
@@ -39,11 +39,13 @@ export class PostComponent extends Component {
     }
 
     render() {
+        const {post} = this.props;
+        
         return <Row
             className="post post--words"
-            id={this.props.post.uid}
+            id={post.uid}
         >
-            <SchemaJsonLdComponent markup={this.props.post.toSchema()}/>
+            <SchemaJsonLdComponent markup={post.toSchema()}/>
             <Col
                 className="post-metadata"
                 s={12}
@@ -51,9 +53,9 @@ export class PostComponent extends Component {
             >
                 <h1 className="post-title">
                     {
-                        this.props.post.sourceUrl ?
+                        post.sourceUrl ?
                             <CampaignLink className="post-title__link"
-                                          href={this.props.post.sourceUrl}>{this.title}</CampaignLink> :
+                                          href={post.sourceUrl}>{this.title}</CampaignLink> :
                             <span className="post-title__text">{this.title}</span>
                     }
                 </h1>
@@ -63,13 +65,25 @@ export class PostComponent extends Component {
                         className="post-date__date post-date__date--published">{this.date.toLocaleString(DateTime.DATE_MED)}</span>
                 </p>
                 {
-                    this.props.post.dateCreated ?
+                    post.dateCreated ?
                         <p className="post-date">
                             <strong className="post-date__label post-date__label--created">Created:</strong>
                             <span
-                                className="post-date__date post-date__date--created">{this.props.post.dateCreated.toLocaleString(DateTime.DATETIME_MED)}</span>
+                                className="post-date__date post-date__date--created">{post.dateCreated.toLocaleString(DateTime.DATETIME_MED)}</span>
                         </p> :
                         null
+                }
+                {
+                    post.tags && post.tags.size
+                        ? <p className="post-tags">
+                            <strong className="post-tags__label">Tags:</strong>
+                            {
+                                post.tags.map(tag => <Fragment key={tag}>
+                                    <span className="post-tags__tag">{tag}</span>&ensp;
+                                </Fragment>)
+                            }
+                        </p>
+                        : null
                 }
             </Col>
             <Col
@@ -78,21 +92,21 @@ export class PostComponent extends Component {
                 l={8}
             >
                 {
-                    typeof this.props.post.body === "string"
+                    typeof post.body === "string"
                         ? <div className="post-body">
                             {
-                                isHtml(this.props.post.body)
+                                isHtml(post.body)
                                     ? <div className="post-body__html">
-                                        <div dangerouslySetInnerHTML={{__html: this.props.post.body}}/>
+                                        <div dangerouslySetInnerHTML={{__html: post.body}}/>
                                     </div>
-                                    : <p><span className="post-body__text">{this.props.post.body}</span></p>
+                                    : <p><span className="post-body__text">{post.body}</span></p>
                             }
                         </div> :
                         null
                 }
                 {
-                    Array.isArray(this.props.post.body)
-                        ? this.props.post.body.map((maybeHtmlString, index) => {
+                    Array.isArray(post.body)
+                        ? post.body.map((maybeHtmlString, index) => {
                             return <div className="post-body" key={index}>
                                 {
                                     isHtml(maybeHtmlString)

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -40,7 +40,7 @@ export class PostComponent extends Component {
 
     render() {
         const {post} = this.props;
-        
+
         return <Row
             className="post post--words"
             id={post.uid}
@@ -78,9 +78,15 @@ export class PostComponent extends Component {
                         ? <p className="post-tags hide-on-med-and-down">
                             <strong className="post-tags__label">Tags:</strong>
                             {
-                                post.tags.map(tag => <Fragment key={tag}><InternalLink className="post-tags__tag"
-                                                                                       href={`${__POSTS_APP_URL__}/tags/${tag}`}>{tag}</InternalLink>
-                                </Fragment>)
+                                post.tags.map(
+                                    tag =>
+                                        <Fragment key={tag}><InternalLink
+                                            className="post-tags__tag"
+                                            href={`${__POSTS_APP_URL__}/tags/${tag}`}
+                                        >
+                                            {tag}
+                                        </InternalLink> </Fragment> // NOTE-RT: We need this ` ` between the `</InternalLink>` and the `</Fragment>` because Safari (Webkit?) seems to collapse `&#0032;` and not insert line breaks between each `<Fragment>` but doesn't with ` `
+                                )
                             }
                         </p>
                         : null

--- a/packages/jsx/src/lib/components/post.jsx
+++ b/packages/jsx/src/lib/components/post.jsx
@@ -9,19 +9,21 @@ import {CampaignLink} from "./link";
 
 export class PostComponent extends Component {
     get width() {
-        return this.containerWidth;
+        const postElement = document.getElementById(this.props.post.uid);
+        return postElement ? postElement.clientWidth : this.props.containerHeight;
     }
 
     get height() {
-        return this.containerHeight;
-    }
-
-    get containerWidth() {
-        return this.props.containerWidth;
+        const postElement = document.getElementById(this.props.post.uid);
+        return postElement ? postElement.clientHeight : this.props.containerWidth;
     }
 
     get containerHeight() {
         return this.props.containerHeight;
+    }
+
+    get containerWidth() {
+        return this.props.containerWidth;
     }
 
     get scaledHeight() {

--- a/packages/jsx/src/lib/components/posts.jsx
+++ b/packages/jsx/src/lib/components/posts.jsx
@@ -48,8 +48,12 @@ export class PostsComponent extends Component {
                     postsArray
                         ? postsArray.map(post => {
                             const Constructor = getComponentForType(post.type);
-                            return <Constructor key={post.uid} post={post} containerHeight={props.containerHeight}
-                                                containerWidth={props.containerWidth}/>;
+                            return <Constructor
+                                key={post.uid}
+                                post={post}
+                                containerHeight={props.containerHeight}
+                                containerWidth={props.containerWidth}
+                            />;
                         })
                         : <div/>
                 }

--- a/packages/jsx/src/lib/components/posts.jsx
+++ b/packages/jsx/src/lib/components/posts.jsx
@@ -37,7 +37,7 @@ export class PostsComponent extends Component {
                 containerHeight={props.containerHeight}
                 useWindowAsScrollContainer={true}
                 elementHeight={elementHeight}
-                infiniteLoadBeginEdgeOffset={window.innerHeight / FETCHING_POSTS_PER_PAGE}
+                infiniteLoadBeginEdgeOffset={window.innerHeight}
                 preloadBatchSize={Infinite.containerHeightScaleFactor(1 / FETCHING_POSTS_PER_PAGE)}
                 preloadAdditionalHeight={Infinite.containerHeightScaleFactor(FETCHING_POSTS_PER_PAGE)}
                 onInfiniteLoad={props.fetchPosts}

--- a/packages/jsx/src/lib/containers/swipeableRoutes.jsx
+++ b/packages/jsx/src/lib/containers/swipeableRoutes.jsx
@@ -6,18 +6,17 @@ import {swipeableChangeIndexCreator} from "../actions";
 import selectors from "../data/selectors";
 
 export const ConnectedSwipeableRoutes = withRouter(connect(
-    (state, {routes, location: routerLocation}) => {
+    (state, {location}) => {
         const swipeableIndex = selectors.getSwipeableIndex(state);
-        const location = selectors.getLocation(state);
-        const indexForRouterLocation = selectors.getIndexForRoute(state, routerLocation.pathname);
+        const indexForRouterLocation = selectors.getIndexForRoute(state, location.pathname);
         const indexForRoute = Number.isInteger(indexForRouterLocation)
             ? indexForRouterLocation
-            : routes.length - 1;
+            : undefined;
         const index = swipeableIndex !== null
             ? swipeableIndex
             : indexForRoute !== -1
                 ? indexForRoute
-                : routes.length - 1;
+                : undefined;
 
         return {
             location,

--- a/packages/jsx/src/lib/util/computePostHeight.js
+++ b/packages/jsx/src/lib/util/computePostHeight.js
@@ -1,6 +1,15 @@
+export const WINDOW_LARGE_BREAKPOINT = 992;
+export const WINDOW_LARGE_PHOTO_SCALE = 8 / 12;
+
 export const computePostHeight = containerWidth => post => {
     if (post.height && post.width) {
-        return containerWidth * post.height / post.width;
+        let scaledHeight = Math.round(containerWidth * post.height / post.width);
+
+        if (window.innerWidth >= WINDOW_LARGE_BREAKPOINT) {
+            scaledHeight = scaledHeight * WINDOW_LARGE_PHOTO_SCALE;
+        }
+
+        return scaledHeight;
     }
 
     if (typeof document !== "undefined" && document.getElementById(post.uid)) {

--- a/packages/jsx/src/lib/util/renderSwipeableRoutes.jsx
+++ b/packages/jsx/src/lib/util/renderSwipeableRoutes.jsx
@@ -1,56 +1,84 @@
 import React from "react";
-import {matchPath, Route} from "react-router";
+import {matchPath, Route, withRouter} from "react-router";
 import {matchRoutes} from "react-router-config";
 import {ConnectedSwipeableRoutes} from "../containers";
 
 export const renderRoute = (routes, route, extraProps) => props => {
     // FIXME-RT: It'd be nice to not have to compute matches for every route here
     // NOTE-RT: Shamelessly stolen from https://github.com/sanfilippopablo/react-swipeable-routes/blob/master/src/index.js#L132
-    const matchedRoutes = matchRoutes(routes, window.location.pathname);
-    const bestMatchedRoute = matchedRoutes[0];
-    const match = matchPath(window.location.pathname, route);
+    const pathname = props.location.pathname;
+    const matchedRoutes = matchRoutes(routes, pathname);
+    const bestMatchedRoute = matchedRoutes[matchedRoutes.length - 1];
+    const matchOptions = {
+        path: route.path,
+        exact: route.exact,
+        strict: route.strict,
+        sensitive: route.sensitive
+    };
+    let match = matchPath(pathname, matchOptions, bestMatchedRoute.route);
 
     if (match) {
-        if (match.path === bestMatchedRoute.match.path) {
-            match.type = "full";
-        } else if (matchedRoutes.length) {
-            match.type = "outOfView";
-        }
+        match.type = "full";
+    } else {
+        match = bestMatchedRoute.match;
+        match.type = "none";
     }
 
     props.match = match;
 
-    return props.match && props.match.type === "full"
-        ? route.render
-            ? route.render({...props, ...extraProps, route: route})
-            : <route.component {...props} {...extraProps} route={route}/>
+    return match.type === "full"
+        ? bestMatchedRoute.route.render
+            ? bestMatchedRoute.route.render({...props, ...extraProps, ...bestMatchedRoute})
+            : <bestMatchedRoute.route.component {...props} {...extraProps} {...bestMatchedRoute}/>
         : null;
 };
 
+// NOTE-RT: Shamelessly stolen from [`react-router-config^1.0.0-beta.4`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-config/modules/renderRoutes.js#L4)
 const buildRouteForRoutes = (extraProps, routes) => (route, i) => <Route // eslint-disable-line react/display-name
     key={route.key || i}
     path={route.path}
     exact={route.exact}
     strict={route.strict}
+    tab={route.tab}
     render={renderRoute(routes, route, extraProps)}
 />;
 
-// NOTE-RT: Shamelessly stolen from [`react-router-config^1.0.0-beta.4`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-config/modules/renderRoutes.js#L4)
-export const renderSwipeableRoutes = (routes, extraProps = {}, swipeableRoutesProps = {}) => {
+export const RenderedSwipeableRoutes = ({location, routes, extraProps, swipeableRoutesProps}) => {
     if (routes) {
         const swipeableRoutes = routes.filter(route => !!route.tab);
-        const nonSwipeableRoutes = routes.filter(route => !route.tab);
 
-        // NOTE-RT: This needs to be a `div` and not a `Fragment` so we can test this with `shallow`
+        let match = null;
+        let matchedUnswipeableRoutes = [];
+
+        routes.forEach(route => {
+            if (match === null) {
+                match = matchPath(location.pathname, route);
+
+                if (match !== null && !swipeableRoutes.includes(route)) {
+                    matchedUnswipeableRoutes.push(route);
+                }
+            }
+        });
+
         return <div className="routes-container routes-container__swipeable">
-            <ConnectedSwipeableRoutes routes={routes} {...swipeableRoutesProps}>
+            <ConnectedSwipeableRoutes {...swipeableRoutesProps}>
                 {swipeableRoutes.map(buildRouteForRoutes(extraProps, routes))}
             </ConnectedSwipeableRoutes>
-            {nonSwipeableRoutes.map(buildRouteForRoutes(extraProps, routes))}
+            {matchedUnswipeableRoutes.map(buildRouteForRoutes(extraProps, routes))}
         </div>;
     }
 
     return null;
+};
+
+export const RenderedSwipeableRoutesForLocation = withRouter(RenderedSwipeableRoutes);
+
+export const renderSwipeableRoutes = (routes, extraProps = {}, swipeableRoutesProps = {}) => {
+    return <RenderedSwipeableRoutesForLocation
+        routes={routes}
+        extraProps={extraProps}
+        swipeableRoutesProps={swipeableRoutesProps}
+    />;
 };
 
 export default renderSwipeableRoutes;

--- a/packages/jsx/test/build/routes/index.jsx
+++ b/packages/jsx/test/build/routes/index.jsx
@@ -13,12 +13,21 @@ const routes = [
         component: Posts,
         path: "/posts",
         exact: true,
-        tab: <span>Posts</span>
+        tab: <span>Posts</span>,
+        routes: [
+            {
+                component: Posts,
+                path: "/posts/:filter"
+            },
+            {
+                component: Posts,
+                path: "/posts/:filter/:filterValue"
+            }
+        ]
     },
     {
         component: Error,
-        path: "/error",
-        exact: true
+        path: "/error"
     },
     {
         component: Error

--- a/packages/jsx/test/unit/src/lib/actions/fetchPosts.js
+++ b/packages/jsx/test/unit/src/lib/actions/fetchPosts.js
@@ -157,7 +157,8 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload (first page)", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE
+                perPage: FETCHING_POSTS_PER_PAGE,
+                type: undefined
             };
             const stubPostsResponse = {
                 posts: ["woof"],
@@ -232,6 +233,7 @@ describe("fetchPosts", function () {
             const stubLoadedPost = Post.fromJSON({dateCreated: DateTime.utc(2018, 8, 22)});
             const stubSearchParams = {
                 perPage: FETCHING_POSTS_PER_PAGE,
+                type: undefined,
                 orderComparator: stubLoadedPost.dateCreated.toISO(),
                 orderBy: "datePublished",
                 orderComparatorType: "String",
@@ -304,7 +306,8 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload (no posts)", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE
+                perPage: FETCHING_POSTS_PER_PAGE,
+                type: undefined
             };
             const stubPostsResponse = {
                 posts: [],
@@ -441,7 +444,8 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload (fetch error)", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE
+                perPage: FETCHING_POSTS_PER_PAGE,
+                type: undefined
             };
             const stubPostsResponse = new Error("woof");
 
@@ -493,7 +497,8 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE
+                perPage: FETCHING_POSTS_PER_PAGE,
+                type: undefined
             };
             const stubPostsResponse = {
                 posts: ["woof"],

--- a/packages/jsx/test/unit/src/lib/actions/fetchPosts.js
+++ b/packages/jsx/test/unit/src/lib/actions/fetchPosts.js
@@ -146,6 +146,13 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_CANCELLED,
                             payload: {
                                 fetchUrl: stubFetchUrl,
+                                searchParams: {
+                                    orderBy: "datePublished",
+                                    orderComparator: stubInitialState.getIn(["posts", "oldest", "global"]).toISO(),
+                                    orderComparatorType: "String",
+                                    orderOperator: "lt",
+                                    perPage: 8
+                                },
                                 oldestPostAvailableDate: stubInitialState.getIn(["posts", "oldest", "global"]),
                                 oldestLoadedPostDate: stubLoadedPost.dateCreated
                             }
@@ -157,8 +164,7 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload (first page)", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE,
-                type: undefined
+                perPage: FETCHING_POSTS_PER_PAGE
             };
             const stubPostsResponse = {
                 posts: ["woof"],
@@ -207,6 +213,7 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_SUCCESS,
                             payload: {
                                 fetchUrl: stubFetchUrl,
+                                searchParams: stubSearchParams,
                                 ...stubPostsResponse
                             }
                         }
@@ -233,7 +240,6 @@ describe("fetchPosts", function () {
             const stubLoadedPost = Post.fromJSON({dateCreated: DateTime.utc(2018, 8, 22)});
             const stubSearchParams = {
                 perPage: FETCHING_POSTS_PER_PAGE,
-                type: undefined,
                 orderComparator: stubLoadedPost.dateCreated.toISO(),
                 orderBy: "datePublished",
                 orderComparatorType: "String",
@@ -294,6 +300,7 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_SUCCESS,
                             payload: {
                                 fetchUrl: stubFetchUrl,
+                                searchParams: stubSearchParams,
                                 ...stubPostsResponse
                             }
                         }
@@ -306,8 +313,7 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload (no posts)", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE,
-                type: undefined
+                perPage: FETCHING_POSTS_PER_PAGE
             };
             const stubPostsResponse = {
                 posts: [],
@@ -345,6 +351,7 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_SUCCESS,
                             payload: {
                                 fetchUrl: stubFetchUrl,
+                                searchParams: stubSearchParams,
                                 ...stubPostsResponse
                             }
                         },
@@ -444,8 +451,7 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload (fetch error)", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE,
-                type: undefined
+                perPage: FETCHING_POSTS_PER_PAGE
             };
             const stubPostsResponse = new Error("woof");
 
@@ -473,6 +479,7 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_FAILURE,
                             payload: {
                                 fetchUrl: stubFetchUrl,
+                                searchParams: stubSearchParams,
                                 error: stubPostsResponse
                             }
                         },
@@ -497,8 +504,7 @@ describe("fetchPosts", function () {
         it("is dispatched with the expected payload", function () {
             const stubFetchUrl = "/woof";
             const stubSearchParams = {
-                perPage: FETCHING_POSTS_PER_PAGE,
-                type: undefined
+                perPage: FETCHING_POSTS_PER_PAGE
             };
             const stubPostsResponse = {
                 posts: ["woof"],
@@ -540,6 +546,7 @@ describe("fetchPosts", function () {
                             type: FETCHING_POSTS_SUCCESS,
                             payload: {
                                 fetchUrl: stubFetchUrl,
+                                searchParams: stubSearchParams,
                                 ...stubPostsResponse
                             }
                         }

--- a/packages/jsx/test/unit/src/lib/components/photo.jsx
+++ b/packages/jsx/test/unit/src/lib/components/photo.jsx
@@ -2,7 +2,10 @@ import {Photo as PhotoEntity} from "@randy.tarampi/js";
 import {expect} from "chai";
 import {shallow} from "enzyme";
 import React from "react";
-import ProgressiveImageWrappedPhotoComponent, {PhotoComponent} from "../../../../../src/lib/components/photo";
+import ProgressiveImageWrappedPhotoComponent, {
+    PhotoComponent,
+    PostMetadataContent
+} from "../../../../../src/lib/components/photo";
 
 describe("Photo", function () {
     let stubPhoto;
@@ -133,7 +136,9 @@ describe("Photo", function () {
             expect(rendered).to.have.className("post--photo");
             expect(rendered).to.have.className("post--loading");
 
-            const links = rendered.find(".post-source__link");
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+            const links = renderedMetadata.find(".post-source__link");
             expect(links).to.have.length(2);
             expect(links.first()).to.have.prop("href", stubPhoto.sourceUrl);
             expect(links.last()).to.have.prop("href", stubPhoto.creator.url);
@@ -179,16 +184,21 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
+            expect(rendered).to.have.descendants(".post-metadata");
+            expect(rendered).to.have.descendants(".post-content");
 
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.not.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.not.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > p > .post-body__text");
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.not.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.not.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > p > .post-body__text");
         });
 
         it("renders (no body)", function () {
@@ -226,15 +236,20 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
+            expect(rendered).to.have.descendants(".post-metadata");
+            expect(rendered).to.have.descendants(".post-content");
 
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.not.have.descendants(".post-body");
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.not.have.descendants(".post-body");
         });
 
         it("renders (plain string body)", function () {
@@ -273,17 +288,21 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
-
             expect(rendered).to.have.descendants(".post-metadata");
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > p > .post-body__text");
+            expect(rendered).to.have.descendants(".post-content");
+
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > p > .post-body__text");
         });
 
         it("renders (html string body)", function () {
@@ -322,17 +341,20 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
-
             expect(rendered).to.have.descendants(".post-metadata");
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > div");
+            expect(rendered).to.have.descendants(".post-content");
+
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > div");
         });
 
         it("renders (array body)", function () {
@@ -375,89 +397,22 @@ describe("Photo", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.have.id(stubProps.post.uid);
             expect(rendered).to.have.className("post--photo");
-
             expect(rendered).to.have.descendants(".post-metadata");
-            expect(rendered).to.have.descendants(".post-title");
-            expect(rendered).to.have.descendants(".post-title__link");
-            expect(rendered).to.have.descendants(".post-date");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--published");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--published");
-            expect(rendered).to.have.descendants(".post-date__label.post-date__label--created");
-            expect(rendered).to.have.descendants(".post-date__date.post-date__date--created");
-            expect(rendered).to.have.descendants(".post-body");
-            expect(rendered).to.have.descendants(".post-body > div");
-            expect(rendered).to.have.descendants(".post-body > p > .post-body__text");
-        });
+            expect(rendered).to.have.descendants(".post-content");
 
-        describe("#width", function () {
-            it("returns the `selected.width`", function () {
-                stubPhoto = PhotoEntity.fromJSON({
-                    id: "woof",
-                    type: "Woof",
-                    source: "Woofdy",
-                    dateCreated: new Date(1900, 0, 1).toISOString(),
-                    datePublished: new Date(2500, 0, 1).toISOString(),
-                    width: -1,
-                    height: -2,
-                    sizedPhotos: [
-                        {url: "woof://woof.woof/woof/woofto", width: 640, height: 480},
-                        {url: "woof://woof.woof/woof/woofto?w=800", width: 800}
-                    ],
-                    title: "Woof woof woof",
-                    body: [
-                        "ʕ•ᴥ•ʔ",
-                        "<span class=\"Woof\">ʕ•ᴥ•ʔ</span>",
-                        "ʕ◠ᴥ◠ʔ"
-                    ],
-                    sourceUrl: "woof://woof.woof/woof",
-                    creator: {
-                        id: -1,
-                        username: "ʕ•ᴥ•ʔ",
-                        name: "ʕ•ᴥ•ʔ",
-                        url: "woof://woof.woof/woof/woof/woof"
-                    }
-                });
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
 
-                const stubProps = {
-                    post: stubPhoto,
-                    containerHeight: 123,
-                    containerWidth: 123,
-                    isLoading: false,
-                    source: stubPhoto.getSizedPhotoForLoading().url
-                };
-                const rendered = shallow(<PhotoComponent {...stubProps}/>);
-
-                expect(rendered).to.be.ok;
-                expect(rendered).to.have.id(stubProps.post.uid);
-                expect(rendered).to.have.className("post--photo");
-
-                const component = rendered.instance();
-                expect(component).to.be.ok;
-                expect(component.width).to.be.ok;
-                expect(component.width).to.eql(component.selected.width);
-            });
-        });
-
-        describe("#height", function () {
-            it("returns the `selected.height`", function () {
-                const stubProps = {
-                    post: stubPhoto,
-                    containerHeight: 123,
-                    containerWidth: 123,
-                    isLoading: false,
-                    source: stubPhoto.getSizedPhotoForLoading().url
-                };
-                const rendered = shallow(<PhotoComponent {...stubProps}/>);
-
-                expect(rendered).to.be.ok;
-                expect(rendered).to.have.id(stubProps.post.uid);
-                expect(rendered).to.have.className("post--photo");
-
-                const component = rendered.instance();
-                expect(component).to.be.ok;
-                expect(component.height).to.be.ok;
-                expect(component.height).to.eql(component.selected.height);
-            });
+            expect(renderedMetadata).to.have.descendants(".post-title");
+            expect(renderedMetadata).to.have.descendants(".post-title__link");
+            expect(renderedMetadata).to.have.descendants(".post-date");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--published");
+            expect(renderedMetadata).to.have.descendants(".post-date__label.post-date__label--created");
+            expect(renderedMetadata).to.have.descendants(".post-date__date.post-date__date--created");
+            expect(renderedMetadata).to.have.descendants(".post-body");
+            expect(renderedMetadata).to.have.descendants(".post-body > div");
+            expect(renderedMetadata).to.have.descendants(".post-body > p > .post-body__text");
         });
 
         describe("#selected", function () {

--- a/packages/jsx/test/unit/src/lib/components/photo.jsx
+++ b/packages/jsx/test/unit/src/lib/components/photo.jsx
@@ -139,9 +139,64 @@ describe("Photo", function () {
             const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
                                                                   title={rendered.instance().title}/>);
             const links = renderedMetadata.find(".post-source__link");
-            expect(links).to.have.length(2);
-            expect(links.first()).to.have.prop("href", stubPhoto.sourceUrl);
+            expect(links).to.have.length(1);
             expect(links.last()).to.have.prop("href", stubPhoto.creator.url);
+        });
+
+        it("renders (tags)", function () {
+            stubPhoto = PhotoEntity.fromJSON({
+                id: "woof",
+                type: "Woof",
+                source: "Woofdy",
+                dateCreated: null,
+                datePublished: new Date(2500, 0, 1).toISOString(),
+                width: -1,
+                height: -2,
+                sizedPhotos: [
+                    {url: "woof://woof.woof/woof/woofto", width: 640, height: 480},
+                    {url: "woof://woof.woof/woof/woofto?w=800", width: 800}
+                ],
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                },
+                tags: [
+                    "woof",
+                    "meow",
+                    "grr"
+                ]
+            });
+
+            const stubProps = {
+                post: stubPhoto,
+                containerHeight: 123,
+                containerWidth: 123,
+                isLoading: false,
+                source: stubPhoto.getSizedPhotoForLoading().url
+            };
+            const rendered = shallow(<PhotoComponent {...stubProps}/>);
+
+            expect(rendered).to.be.ok;
+            expect(rendered).to.have.id(stubProps.post.uid);
+            expect(rendered).to.have.className("post--photo");
+            expect(rendered).to.have.descendants(".post-metadata");
+            expect(rendered).to.have.descendants(".post-content");
+
+            const renderedMetadata = shallow(<PostMetadataContent post={rendered.instance().props.post}
+                                                                  title={rendered.instance().title}/>);
+
+            expect(renderedMetadata).to.have.descendants(".post-tags");
+            expect(renderedMetadata).to.have.descendants(".post-tags__label");
+            expect(renderedMetadata).to.have.descendants(".post-tags__tag");
         });
 
         it("renders (no dateCreated)", function () {

--- a/packages/jsx/test/unit/src/lib/components/post.jsx
+++ b/packages/jsx/test/unit/src/lib/components/post.jsx
@@ -8,7 +8,40 @@ describe("Post", function () {
     let stubPost;
 
     beforeEach(function () {
-        stubPost = PostEntity.fromJSON({id: "woof", source: "ᶘ ◕ᴥ◕ᶅ", dateCreated: new Date(2500, 0, 1).toISOString()});
+        stubPost = PostEntity.fromJSON({
+            id: "woof",
+            source: "ᶘ ◕ᴥ◕ᶅ",
+            dateCreated: new Date(2500, 0, 1).toISOString()
+        });
+    });
+
+    it("renders (tags)", function () {
+        stubPost = PostEntity.fromJSON({
+            id: "woof",
+            source: "ᶘ ◕ᴥ◕ᶅ",
+            datePublished: new Date(2500, 0, 1).toISOString(),
+            sourceUrl: "woof.woof/woof",
+            tags: [
+                "woof",
+                "meow",
+                "grr"
+            ]
+        });
+
+        const stubProps = {
+            post: stubPost,
+            containerHeight: 123,
+            containerWidth: 123
+        };
+        const rendered = shallow(<Post {...stubProps}/>);
+
+        expect(rendered).to.be.ok;
+        expect(rendered).to.have.id(stubProps.post.uid);
+        expect(rendered).to.have.className("post");
+
+        expect(rendered).to.have.descendants(".post-tags");
+        expect(rendered).to.have.descendants(".post-tags__label");
+        expect(rendered).to.have.descendants(".post-tags__tag");
     });
 
     it("renders (url instead of title)", function () {

--- a/packages/jsx/test/unit/src/lib/components/posts.jsx
+++ b/packages/jsx/test/unit/src/lib/components/posts.jsx
@@ -5,6 +5,7 @@ import {Set} from "immutable";
 import React from "react";
 import Infinite from "react-infinite";
 import sinon from "sinon";
+import {FETCHING_POSTS_PER_PAGE} from "../../../../../src/lib/actions/fetchPosts";
 import LoadingSpinner from "../../../../../src/lib/components/loadingSpinner";
 import DimensionsContainerWrappedPosts, {
     DimensionsWrappedPosts,
@@ -12,7 +13,6 @@ import DimensionsContainerWrappedPosts, {
 } from "../../../../../src/lib/components/posts";
 import computePostHeight from "../../../../../src/lib/util/computePostHeight";
 import getComponentForType from "../../../../../src/lib/util/getComponentForType";
-import {FETCHING_POSTS_PER_PAGE} from "../../../../../src/lib/actions/fetchPosts";
 
 describe("Posts", function () {
     let stubPosts;
@@ -62,7 +62,7 @@ describe("Posts", function () {
                 <Infinite
                     {...expectedProps}
                     useWindowAsScrollContainer={true}
-                    infiniteLoadBeginEdgeOffset={window.innerHeight / FETCHING_POSTS_PER_PAGE}
+                    infiniteLoadBeginEdgeOffset={window.innerHeight}
                     preloadBatchSize={Infinite.containerHeightScaleFactor(1 / FETCHING_POSTS_PER_PAGE)}
                     preloadAdditionalHeight={Infinite.containerHeightScaleFactor(FETCHING_POSTS_PER_PAGE)}
                     elementHeight={stubPosts.toArray().map(computePostHeight(stubProps.containerWidth))}
@@ -99,7 +99,7 @@ describe("Posts", function () {
                 <Infinite
                     {...expectedProps}
                     useWindowAsScrollContainer={true}
-                    infiniteLoadBeginEdgeOffset={window.innerHeight / FETCHING_POSTS_PER_PAGE}
+                    infiniteLoadBeginEdgeOffset={window.innerHeight}
                     preloadBatchSize={Infinite.containerHeightScaleFactor(1 / FETCHING_POSTS_PER_PAGE)}
                     preloadAdditionalHeight={Infinite.containerHeightScaleFactor(FETCHING_POSTS_PER_PAGE)}
                     elementHeight={[window.innerHeight]}

--- a/packages/jsx/test/unit/src/lib/containers/posts.jsx
+++ b/packages/jsx/test/unit/src/lib/containers/posts.jsx
@@ -30,7 +30,7 @@ describe("Posts", function () {
         stubStore = mockStore(stubInitialState);
 
         stubPhotos = List([
-            Photo.fromJSON({id: "meow", dateCreated: new Date(1900, 0, 1).toISOString()}),
+            Photo.fromJSON({id: "meow", dateCreated: new Date(1900, 0, 1).toISOString(), tags: ["meow"]}),
             Photo.fromJSON({id: "rawr", dateCreated: new Date(3000, 0, 1).toISOString()})
         ]);
         stubWords = List([
@@ -94,7 +94,7 @@ describe("Posts", function () {
     });
 
     it("propagates props (any post type)", function () {
-        const stubProps = {fetchUrl: "/woof"};
+        const stubProps = {fetchUrl: "/woof", match: {params: {}}};
         const fetchPostsStub = sinon.stub().returns(() => Promise.resolve());
         const proxyquiredPosts = proxyquire("../../../../../src/lib/containers/posts", {
             "../actions/fetchPosts": {
@@ -125,8 +125,41 @@ describe("Posts", function () {
         expect(rendered).to.have.prop("fetchPosts");
     });
 
+    it("propagates props (has tags)", function () {
+        const stubProps = {fetchUrl: "/woof", match: {params: {filter: "tags", filterValue: "meow"}}};
+        const fetchPostsStub = sinon.stub().returns(() => Promise.resolve());
+        const proxyquiredPosts = proxyquire("../../../../../src/lib/containers/posts", {
+            "../actions/fetchPosts": {
+                "default": fetchPostsStub
+            }
+        });
+        const Posts = proxyquiredPosts.default;
+
+        const rendered = shallow(stubStore)(<Posts {...stubProps} />);
+        let renderCount = 1;
+
+        expect(rendered).to.be.ok;
+        expect(rendered).to.have.props(stubProps);
+
+        expect(api.createIsLoadingUrlSelector.callCount).to.eql(renderCount);
+        expect(api.createGetErrorForUrlSelector.callCount).to.eql(renderCount);
+        expect(selectors.getPostsSortedByDate.callCount).to.eql(renderCount);
+        sinon.assert.calledWith(selectors.getPostsSortedByDate, stubInitialState);
+        expect(isLoadingForUrlSelectorStub.callCount).to.eql(renderCount);
+        sinon.assert.calledWith(isLoadingForUrlSelectorStub, stubInitialState, stubProps.fetchUrl);
+        expect(getErrorForUrlSelectorStub.callCount).to.eql(renderCount);
+        sinon.assert.calledWith(getErrorForUrlSelectorStub, stubInitialState, stubProps.fetchUrl);
+        expect(rendered).to.have.prop("isLoading", isLoadingForUrlStub);
+        expect(rendered).to.have.prop("error", getErrorForUrlStub);
+        expect(rendered).to.have.prop("posts");
+        expect(rendered.prop("posts").size).to.eql(1);
+
+        expect(fetchPostsStub.notCalled).to.eql(true);
+        expect(rendered).to.have.prop("fetchPosts");
+    });
+
     it("propagates props (only `Photo`s)", function () {
-        const stubProps = {fetchUrl: "/woof", type: "Photo"};
+        const stubProps = {fetchUrl: "/woof", type: "Photo", match: {params: {}}};
         const fetchPostsStub = sinon.stub().returns(() => Promise.resolve());
         const proxyquiredPosts = proxyquire("../../../../../src/lib/containers/posts", {
             "../actions/fetchPosts": {
@@ -158,7 +191,7 @@ describe("Posts", function () {
     });
 
     it("propagates props (only `Post`s)", function () {
-        const stubProps = {fetchUrl: "/woof", type: "Post"};
+        const stubProps = {fetchUrl: "/woof", type: "Post", match: {params: {}}};
         const fetchPostsStub = sinon.stub().returns(() => Promise.resolve());
         const proxyquiredPosts = proxyquire("../../../../../src/lib/containers/posts", {
             "../actions/fetchPosts": {
@@ -190,7 +223,7 @@ describe("Posts", function () {
     });
 
     it("dispatches `fetchPosts` properly", function () {
-        const stubProps = {fetchUrl: "/woof"};
+        const stubProps = {fetchUrl: "/woof", match: {params: {}}};
         const fetchPostsStub = sinon.stub().returns(() => Promise.resolve());
         const proxyquiredPosts = proxyquire("../../../../../src/lib/containers/posts", {
             "../actions/fetchPosts": {

--- a/packages/jsx/test/unit/src/lib/data/ui.js
+++ b/packages/jsx/test/unit/src/lib/data/ui.js
@@ -91,9 +91,9 @@ describe("ui", function () {
         it("reduces the correct state (has existing state)", function () {
             stubInitialState = Map({
                 routes: List([
-                    {path: "woof", tab: 1, pathRegExp: /wooof/}, // NOTE-RT: Deliberately match `woof` to `/.*/`
-                    {path: "meow", tab: 2, pathRegExp: /meow/},
-                    {path: "grr", tab: 3, pathRegExp: /.*/}
+                    {path: "woof", tab: 1},
+                    {path: "meow", tab: 2},
+                    {path: "grr", tab: 3}
                 ]),
                 swipeable: Map({
                     index: 0,
@@ -117,10 +117,10 @@ describe("ui", function () {
             const route = getRouteForIndex(updatedState, 1);
             expect(route).to.eql(stubInitialState.get("routes").get(1));
             const routeIndex = getIndexForRoute(updatedState, stubRoute);
-            expect(routeIndex).to.eql(2);
+            expect(routeIndex).to.eql(0);
 
             const swipeableIndex = getSwipeableIndex(updatedState);
-            expect(swipeableIndex).to.eql(2);
+            expect(swipeableIndex).to.eql(0);
         });
     });
 
@@ -149,9 +149,9 @@ describe("ui", function () {
         it("reduces the correct state (has existing state)", function () {
             stubInitialState = Map({
                 routes: List([
-                    {path: "woof", tab: 1, pathRegExp: /woof/}, // NOTE-RT: Properly match `woof`
-                    {path: "meow", tab: 2, pathRegExp: /meow/},
-                    {path: "grr", tab: 3, pathRegExp: /.*/}
+                    {path: "woof", tab: 1},
+                    {path: "meow", tab: 2},
+                    {path: "grr", tab: 3}
                 ]),
                 swipeable: Map({
                     index: 0,
@@ -213,9 +213,9 @@ describe("ui", function () {
         it("reduces the correct state (has existing state)", function () {
             stubInitialState = Map({
                 routes: List([
-                    {path: "woof", tab: 1, pathRegExp: /woof/}, // NOTE-RT: Properly match `woof`
-                    {path: "meow", tab: 2, pathRegExp: /meow/},
-                    {path: "grr", tab: 3, pathRegExp: /.*/}
+                    {path: "woof", tab: 1},
+                    {path: "meow", tab: 2},
+                    {path: "grr", tab: 3}
                 ]),
                 swipeable: Map({
                     index: 0,

--- a/packages/jsx/test/unit/src/lib/util/computePostHeight.js
+++ b/packages/jsx/test/unit/src/lib/util/computePostHeight.js
@@ -1,7 +1,7 @@
 import {Photo} from "@randy.tarampi/js";
 import {expect} from "chai";
 import {JSDOM} from "jsdom";
-import computePostHeight from "../../../../../src/lib/util/computePostHeight";
+import computePostHeight, {WINDOW_LARGE_PHOTO_SCALE} from "../../../../../src/lib/util/computePostHeight";
 
 describe("computePostHeight", function () {
     const globalWindow = global.window;
@@ -18,7 +18,7 @@ describe("computePostHeight", function () {
         const computedPostHeight = computePostHeight(stubContainerWidth)(stubPost);
 
         expect(computedPostHeight).to.be.ok;
-        expect(computedPostHeight).to.eql(500); // NOTE-RT: 500 * 1000 / 1000
+        expect(computedPostHeight).to.eql(500 * WINDOW_LARGE_PHOTO_SCALE); // NOTE-RT: 500 * 1000 / 1000 * WINDOW_LARGE_PHOTO_SCALE
     });
 
     // NOTE-RT: I really don't know when we'd be falling into here. I think that might just be me requiring coffee though...

--- a/packages/jsx/test/unit/src/lib/util/renderSwipeableRoutes.jsx
+++ b/packages/jsx/test/unit/src/lib/util/renderSwipeableRoutes.jsx
@@ -1,9 +1,10 @@
 import {expect} from "chai";
 import {Map} from "immutable/dist/immutable";
+import React from "react";
 import {Route} from "react-router";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import renderSwipeableRoutes, {renderRoute} from "../../../../../src/lib/util/renderSwipeableRoutes";
+import {RenderedSwipeableRoutes, renderRoute} from "../../../../../src/lib/util/renderSwipeableRoutes";
 import routes from "../../../../build/routes";
 import {shallow} from "../../../../util";
 
@@ -20,21 +21,25 @@ describe("renderSwipeableRoutes", function () {
         stubStore = mockStore(stubInitialState);
     });
 
-    it("handles no routes", function () {
-        const stubRoutes = null;
-        const component = renderSwipeableRoutes(stubRoutes);
-        expect(component).to.eql(null);
-    });
+    describe("RenderedSwipeableRoutes", function () {
+        it("handles no routes", function () {
+            const stubRoutes = null;
+            const rendered = shallow(stubStore)(<RenderedSwipeableRoutes routes={stubRoutes}/>);
+            expect(rendered).to.be.ok;
+            expect(rendered).to.not.have.className("routes-container");
+            expect(rendered).to.not.have.className("routes-container__swipeable");
+        });
 
-    it("delegates to `ConnectedSwipeableRoutes`", function () {
-        const stubRoutes = routes;
-        const component = renderSwipeableRoutes(stubRoutes);
-        expect(component).to.be.ok;
-
-        const rendered = shallow(stubStore)(component);
-        expect(rendered).to.be.ok;
-        expect(rendered).to.have.descendants(Route);
-        expect(rendered.find(Route)).to.have.length(stubRoutes.length);
+        it("delegates to `ConnectedSwipeableRoutes`", function () {
+            const stubLocation = {pathname: "/posts/woof"};
+            const stubRoutes = routes;
+            const rendered = shallow(stubStore)(<RenderedSwipeableRoutes routes={stubRoutes} location={stubLocation}/>);
+            expect(rendered).to.be.ok;
+            expect(rendered).to.have.className("routes-container");
+            expect(rendered).to.have.className("routes-container__swipeable");
+            expect(rendered).to.have.descendants(Route);
+            expect(rendered.find(Route)).to.have.length(stubRoutes.filter(route => route.path).length);
+        });
     });
 
     describe("renderRoute", function () {
@@ -48,37 +53,34 @@ describe("renderSwipeableRoutes", function () {
         });
 
         it("doesn't render a non-matching route", function () {
+            const stubLocation = {pathname: "/woof"};
             const stubRoutes = routes;
             const component = renderRoute(stubRoutes, stubRoutes[0]);
             expect(component).to.be.ok;
 
-            const actualComponent = component({});
+            const actualComponent = component({location: stubLocation});
             expect(actualComponent).to.eql(null);
         });
 
         it("doesn't render an out-of-view route", function () {
-            global._jsdom.reconfigure({url: "http://localhost:8080/error"});
-            global.window = global._jsdom.window;
-            global.location = global.window.location;
-
-            const stubRoutes = routes;
-            const component = renderRoute(stubRoutes, stubRoutes[0]);
-            expect(component).to.be.ok;
-
-            const actualComponent = component({});
-            expect(actualComponent).to.eql(null);
-        });
-
-        it("renders a matched route", function () {
-            global._jsdom.reconfigure({url: "http://localhost:8080/posts"});
-            global.window = global._jsdom.window;
-            global.location = global.window.location;
+            const stubLocation = {pathname: "/posts/foo"};
 
             const stubRoutes = routes;
             const component = renderRoute(stubRoutes, stubRoutes[1]);
             expect(component).to.be.ok;
 
-            const actualComponent = component({});
+            const actualComponent = component({location: stubLocation});
+            expect(actualComponent).to.eql(null);
+        });
+
+        it("renders a matched route", function () {
+            const stubLocation = {pathname: "/posts"};
+
+            const stubRoutes = routes;
+            const component = renderRoute(stubRoutes, stubRoutes[1]);
+            expect(component).to.be.ok;
+
+            const actualComponent = component({location: stubLocation});
             expect(actualComponent).to.be.ok;
         });
     });

--- a/packages/printables/package.json
+++ b/packages/printables/package.json
@@ -27,7 +27,7 @@
     "prepare": "if [ -z \"$IS_PUBLISHING\" ]; then npm run build; fi;",
     "prepack": "if [ -z \"$RELEASE\" ] && [ -z \"$CI\" ]; then NODE_ENV=prd npm run build; fi; if [ ! -d \"./dist\" ] && [ ! -d \"./build\" ]; then exit 74; fi;",
     "prepublishOnly": "npm shrinkwrap",
-    "cover": "rm -rf coverage/ .nyc_output/; NODE_ENV=test npx nyc gulp -LLLL --color test",
+    "cover": "rm -rf coverage/ .nyc_output/; NODE_ENV=test nyc gulp -LLLL --color test",
     "clean": "gulp -LLLL --color clean",
     "preuninstall": "npm run clean"
   },

--- a/packages/resume/package.json
+++ b/packages/resume/package.json
@@ -59,7 +59,7 @@
     "resume:pdf": " NODE_ENV=printable CAMPAIGN_SOURCE=$(node -p \"require(\\\"./package.json\\\").name\") CAMPAIGN_MEDIUM=pdf CAMPAIGN_CONTENT=$(node -p \"require(\\\"./package.json\\\").version\") gulp resume:pdf",
     "resume:html": " NODE_ENV=printable CAMPAIGN_SOURCE=$(node -p \"require(\\\"./package.json\\\").name\") CAMPAIGN_MEDIUM=html CAMPAIGN_CONTENT=$(node -p \"require(\\\"./package.json\\\").version\") gulp resume:html",
     "docs": "gulp -LLLL --color docs",
-    "cover": "rm -rf coverage/ .nyc_output/; NODE_ENV=test npx nyc gulp -LLLL --color test",
+    "cover": "rm -rf coverage/ .nyc_output/; NODE_ENV=test nyc gulp -LLLL --color test",
     "clean": "gulp -LLLL --color clean",
     "preuninstall": "npm run clean"
   },

--- a/packages/service/src/db/schema/post.js
+++ b/packages/service/src/db/schema/post.js
@@ -83,7 +83,9 @@ const post = new Schema({
     },
     tags: {
         type: [String],
-        set: tags => tags && tags.filter(tag => !!tag)
+        lowercase: true,
+        set: tags => tags && tags
+            .filter(tag => !!tag)
     },
     lat: {
         type: Number

--- a/packages/service/src/lib/searchParams.js
+++ b/packages/service/src/lib/searchParams.js
@@ -193,7 +193,9 @@ class SearchParams extends SearchParamsRecord {
 
         if (this.tags) { // FIXME-RT: Ideally this would do a filtered query on an index, but let's save that for when I blow this up and move the logic into db/models/post
             filters.tags = {
-                contains: this.tags.split(",")
+                contains: this.tags
+                    .split(",")
+                    .map(string => string.toLowerCase())
             };
 
             if (this.type) {

--- a/packages/service/src/lib/util/xRayedAwsSdk.js
+++ b/packages/service/src/lib/util/xRayedAwsSdk.js
@@ -4,15 +4,19 @@ import logger from "../logger";
 
 Aws.Config.logger = logger;
 
-let AwsClient = Aws;
+export const buildAwsClient = () => {
+    let awsClient = Aws;
 
-if (!process.env.IS_OFFLINE && process.env.NODE_ENV !== "test") {
-    const AwsXRay = require("aws-xray-sdk");
-    AwsXRay.setLogger(logger);
-    AwsXRay.captureHTTPsGlobal(http);
-    AwsClient = AwsXRay.captureAWS(Aws);
-}
+    if (!process.env.IS_OFFLINE && process.env.NODE_ENV !== "test") {
+        const AwsXRay = require("aws-xray-sdk");
+        AwsXRay.setLogger(logger);
+        AwsXRay.captureHTTPsGlobal(http);
+        awsClient = AwsXRay.captureAWS(Aws);
+    }
 
-export const XRayedAwsSdk = AwsClient;
+    return awsClient;
+};
+
+export const XRayedAwsSdk = buildAwsClient();
 
 export default XRayedAwsSdk;

--- a/packages/service/test/01_setup.js
+++ b/packages/service/test/01_setup.js
@@ -11,7 +11,7 @@ if (process.env.IS_OFFLINE || process.env.NODE_ENV === "test") {
     dynamoose.local();
 }
 
-// process.env.AWS_XRAY_CONTEXT_MISSING = "LOG_ERROR";
+process.env.AWS_XRAY_CONTEXT_MISSING = "LOG_ERROR";
 
 process.env.LOCAL_DIRECTORY = "LOCAL_DIRECTORY";
 

--- a/packages/service/test/integration/src/db/models/post.js
+++ b/packages/service/test/integration/src/db/models/post.js
@@ -31,7 +31,7 @@ describe("Post", function () {
                 url: "woof://woof.woof/woof/woof/woof"
             },
             tags: [
-                "woof",
+                "Woof",
                 "meow",
                 "",
                 "grr"
@@ -95,7 +95,7 @@ describe("Post", function () {
             expect(createdPost.uid).to.eql(stubPost.uid);
             const postFromDb = await PostModel.get({id: createdPost.id, source: createdPost.source});
             expect(postFromDb).to.be.ok;
-            expect(postFromDb.tags).to.have.all.members(stubPost.tags.filter(tag => !!tag).toArray());
+            expect(postFromDb.tags).to.have.all.members(stubPost.tags.filter(tag => !!tag).map(tag => tag.toLowerCase()).toArray());
             expect(postFromDb.tags).to.not.have.members([""]);
         });
     });
@@ -152,7 +152,7 @@ describe("Post", function () {
                         url: "grr://grr.grr/grr/grr/grr"
                     },
                     tags: [
-                        "woof"
+                        "Woof"
                     ]
                 })
             ]);

--- a/packages/service/test/unit/src/lib/searchParams.js
+++ b/packages/service/test/unit/src/lib/searchParams.js
@@ -172,6 +172,66 @@ describe("SearchParams", function () {
             });
         });
 
+        it("should properly format properties for tags", function () {
+            const searchParams = SearchParams.fromJS({
+                tags: "woof"
+            });
+
+            expect(searchParams.Dynamoose).to.eql({
+                _filter: {
+                    tags: {contains: ["woof"]}
+                },
+                _options: {limit: 100, descending: true, all: false}
+            });
+        });
+
+        it("should properly format properties for tags & type", function () {
+            const searchParams = SearchParams.fromJS({
+                tags: "woof,meow",
+                type: "Post"
+            });
+
+            expect(searchParams.Dynamoose).to.eql({
+                _filter: {
+                    tags: {contains: ["woof", "meow"]},
+                    type: "Post"
+                },
+                _options: {limit: 100, descending: true, all: false}
+            });
+        });
+
+        it("should properly format properties for tags & source", function () {
+            const searchParams = SearchParams.fromJS({
+                tags: "woof",
+                source: "tumblr"
+            });
+
+            expect(searchParams.Dynamoose).to.eql({
+                _filter: {
+                    tags: {contains: ["woof"]},
+                    source: "tumblr"
+                },
+                _options: {limit: 100, descending: true, all: false}
+            });
+        });
+
+        it("should properly format properties for tags & orderBy", function () {
+            const searchParams = SearchParams.fromJS({
+                tags: "woof",
+                orderBy: "meow",
+                orderOperator: "gt",
+                orderComparator: "5"
+            });
+
+            expect(searchParams.Dynamoose).to.eql({
+                _filter: {
+                    tags: {contains: ["woof"]},
+                    [searchParams.orderBy]: {[searchParams.orderOperator]: Number(searchParams.orderComparator)}
+                },
+                _options: {limit: 100, descending: true, all: false}
+            });
+        });
+
         it("should properly format properties for type", function () {
             const searchParams = SearchParams.fromJS({type: "woof"});
 

--- a/packages/service/test/unit/src/lib/searchParams.js
+++ b/packages/service/test/unit/src/lib/searchParams.js
@@ -187,7 +187,7 @@ describe("SearchParams", function () {
 
         it("should properly format properties for tags & type", function () {
             const searchParams = SearchParams.fromJS({
-                tags: "woof,meow",
+                tags: "woof,Meow",
                 type: "Post"
             });
 

--- a/packages/service/test/unit/src/lib/util.js
+++ b/packages/service/test/unit/src/lib/util.js
@@ -1,5 +1,7 @@
+import AwsXRay from "aws-xray-sdk";
 import {expect} from "chai";
-import {firstResolved} from "../../../../src/lib/util";
+import sinon from "sinon";
+import {buildAwsClient, firstResolved} from "../../../../src/lib/util";
 import {timedPromise} from "../../../lib/util";
 
 describe("util", function () {
@@ -53,6 +55,36 @@ describe("util", function () {
                     expect(error.message).to.match(/`firstResolved` failed and returned 2 errors/);
                     expect(error.errors).to.have.length(2);
                 });
+        });
+    });
+
+    describe("buildAwsClient", function () {
+        const originalNodeEnv = process.env.NODE_ENV;
+
+        beforeEach(function () {
+            sinon.stub(AwsXRay, "setLogger");
+        });
+
+        afterEach(function () {
+            process.env.NODE_ENV = originalNodeEnv;
+
+            AwsXRay.setLogger.restore();
+        });
+
+        it("returns a client for NODE_ENV=test", function () {
+            const awsClient = buildAwsClient();
+
+            expect(awsClient).to.be.ok;
+            expect(AwsXRay.setLogger.notCalled).to.eql(true);
+        });
+
+        it("returns a client for NODE_ENV!=test", function () {
+            process.env.NODE_ENV = "woof";
+
+            const awsClient = buildAwsClient();
+
+            expect(awsClient).to.be.ok;
+            expect(AwsXRay.setLogger.calledOnce).to.eql(true);
         });
     });
 });

--- a/packages/www/src/public/routes/index.jsx
+++ b/packages/www/src/public/routes/index.jsx
@@ -9,7 +9,8 @@ import Main from "../views/main";
 export const PhotosRouteHandler = props => <Redirect {...props} to="/blog/photos"/>;
 export const WordsRouteHandler = props => <Redirect {...props} to="/blog/words"/>;
 export const BlogRouteHandler = props => <ConnectedPosts fetchUrl={`${__POSTS_SERVICE_URL__}`} {...props} />;
-export const BlogPostRouteHandler = props => <BlogRouteHandler fetchUrl={`${__POSTS_SERVICE_URL__}`} type="Post" {...props} />;
+export const BlogWordsRouteHandler = props => <BlogRouteHandler fetchUrl={`${__POSTS_SERVICE_URL__}`}
+                                                                type="Post" {...props} />;
 export const BlogPhotoRouteHandler = props => <BlogRouteHandler fetchUrl={`${__POSTS_SERVICE_URL__}`} type="Photo" {...props} />;
 
 const augmentWithParent = (parent = null) => ({routes, ...route}) => {
@@ -62,17 +63,23 @@ const routes = [
                 path: "/blog/photos"
             },
             {
-                component: BlogPostRouteHandler,
+                component: BlogWordsRouteHandler,
                 exact: true,
                 path: "/blog/words"
             },
             {
-                component: BlogRouteHandler,
-                path: "/blog/:filter"
+                component: BlogPhotoRouteHandler,
+                exact: true,
+                path: "/blog/photos/:filter(tags)/:filterValue"
+            },
+            {
+                component: BlogWordsRouteHandler,
+                exact: true,
+                path: "/blog/words/:filter(tags)/:filterValue"
             },
             {
                 component: BlogRouteHandler,
-                path: "/blog/:filter/:filterValue",
+                path: "/blog/:filter(tags)/:filterValue"
             }
         ]
     },

--- a/packages/www/src/public/routes/index.jsx
+++ b/packages/www/src/public/routes/index.jsx
@@ -28,54 +28,63 @@ const routes = [
         component: Main,
         exact: true,
         path: "/",
-        tab: <Tab title={ // FIXME-RT: Ideally these `Tab`s wouldn't be instantiated, but stateless components. Can't do that because of how `react-materialize` and `$` interact to manage the selection state internally. Maybe this goes away with `react-materialize^3` and `materialize^1`?
-            <Fragment>
-                <i className="far fa-hand-paper"></i>
-                <span className="hide-on-med-and-down">&nbsp;|&nbsp;Hey!</span>
-            </Fragment>
-        }></Tab>
+        tab: <Tab
+            key="/"
+            title={ // FIXME-RT: Ideally these `Tab`s wouldn't be instantiated, but stateless components. Can't do that because of how `react-materialize` and `$` interact to manage the selection state internally. Maybe this goes away with `react-materialize^3` and `materialize^1`?
+                <Fragment>
+                    <i className="far fa-hand-paper"></i>
+                    <span className="hide-on-med-and-down">&nbsp;|&nbsp;Hey!</span>
+                </Fragment>
+            }
+        />
     },
     {
         component: BlogRouteHandler,
-        exact: true,
         path: "/blog",
-        tab: <Tab title={
-            <Fragment>
-                <i className="fas fa-comment-alt"></i>
-                <span className="hide-on-med-and-down">&nbsp;|&nbsp;Blog</span>
-            </Fragment>
-        }/>
+        tab: <Tab
+            key="/blog"
+            title={
+                <Fragment>
+                    <i className="fas fa-comment-alt"></i>
+                    <span className="hide-on-med-and-down">&nbsp;|&nbsp;Blog</span>
+                </Fragment>
+            }
+        />
     },
     {
         component: ConnectedLetter,
         path: "/letter/:variant?",
-        tab: <Tab title={
-            <Fragment>
-                <i className="fas fa-file-signature"></i>
-                <span className="hide-on-med-and-down">&nbsp;|&nbsp;Hire me</span>
-            </Fragment>
-        }/>
+        tab: <Tab
+            key="/letter"
+            title={
+                <Fragment>
+                    <i className="fas fa-file-signature"></i>
+                    <span className="hide-on-med-and-down">&nbsp;|&nbsp;Hire me</span>
+                </Fragment>
+            }
+        />
     },
     {
         component: ConnectedResume,
         path: "/resume/:variant?",
-        tab: <Tab title={
-            <Fragment>
-                <i className="fas fa-portrait"></i>
-                <span className="hide-on-med-and-down">&nbsp;|&nbsp;About me</span>
-            </Fragment>
-        }/>
+        tab: <Tab
+            key="/resume"
+            title={
+                <Fragment>
+                    <i className="fas fa-portrait"></i>
+                    <span className="hide-on-med-and-down">&nbsp;|&nbsp;About me</span>
+                </Fragment>
+            }
+        />
     },
 
     // NOTE-RT: We need to render these redirect in `ReduxRouterRoot` for them to work so these need to be pulled out
     {
         component: PhotosRouteHandler,
-        exact: true,
         path: "/photos"
     },
     {
         component: WordsRouteHandler,
-        exact: true,
         path: "/words"
     },
 

--- a/packages/www/src/public/routes/index.jsx
+++ b/packages/www/src/public/routes/index.jsx
@@ -7,9 +7,9 @@ import {Tab} from "react-materialize";
 import {Redirect} from "react-router";
 import Main from "../views/main";
 
-export const PhotosRouteHandler = () => <Redirect to="/blog"/>;
-export const WordsRouteHandler = () => <Redirect to="/blog"/>;
-export const BlogRouteHandler = () => <ConnectedPosts fetchUrl={`${__POSTS_SERVICE_URL__}`}/>;
+export const PhotosRouteHandler = props => <Redirect {...props} to="/blog"/>;
+export const WordsRouteHandler = props => <Redirect {...props} to="/blog"/>;
+export const BlogRouteHandler = props => <ConnectedPosts fetchUrl={`${__POSTS_SERVICE_URL__}`} {...props} />;
 
 const augmentWithPathRegExp = ({routes, ...route}) => {
     if (route.path) {

--- a/packages/www/test/unit/public/routes/index.jsx
+++ b/packages/www/test/unit/public/routes/index.jsx
@@ -6,7 +6,13 @@ import React from "react";
 import {Redirect} from "react-router";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import {BlogRouteHandler, PhotosRouteHandler, WordsRouteHandler} from "../../../../src/public/routes";
+import {
+    BlogPhotoRouteHandler,
+    BlogRouteHandler,
+    BlogWordsRouteHandler,
+    PhotosRouteHandler,
+    WordsRouteHandler
+} from "../../../../src/public/routes";
 
 describe("routes", function () {
     let mockStore;
@@ -50,6 +56,28 @@ describe("routes", function () {
             expect(rendered).to.be.ok;
             expect(rendered).to.contain(
                 <ConnectedPosts fetchUrl={`${__POSTS_SERVICE_URL__}`}/>
+            );
+        });
+    });
+
+    describe("BlogPhotoRouteHandler", function () {
+        it("renders", function () {
+            const rendered = shallow(stubStore)(<BlogPhotoRouteHandler/>);
+
+            expect(rendered).to.be.ok;
+            expect(rendered).to.contain(
+                <BlogRouteHandler fetchUrl={`${__POSTS_SERVICE_URL__}`} type="Photo"/>
+            );
+        });
+    });
+
+    describe("BlogWordsRouteHandler", function () {
+        it("renders", function () {
+            const rendered = shallow(stubStore)(<BlogWordsRouteHandler/>);
+
+            expect(rendered).to.be.ok;
+            expect(rendered).to.contain(
+                <BlogRouteHandler fetchUrl={`${__POSTS_SERVICE_URL__}`} type="Post"/>
             );
         });
     });

--- a/packages/www/test/unit/public/routes/index.jsx
+++ b/packages/www/test/unit/public/routes/index.jsx
@@ -27,7 +27,7 @@ describe("routes", function () {
 
             expect(rendered).to.be.ok;
             expect(rendered).to.contain(
-                <Redirect to="/blog"/>
+                <Redirect to="/blog/words"/>
             );
         });
     });
@@ -38,7 +38,7 @@ describe("routes", function () {
 
             expect(rendered).to.be.ok;
             expect(rendered).to.contain(
-                <Redirect to="/blog"/>
+                <Redirect to="/blog/photos"/>
             );
         });
     });


### PR DESCRIPTION
Close #76 and #131 by way of #200 and #199 respectively.

Meat
---
- #200 – Actually do something with `tags` and close #76.
- #199 – Rework `Post` and `Photo` for `.xl` screens and close #131.
