### PR TITLE
perf(travis): Roll back to using `trusty` on builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - node_js: '11'
 env:
   global:
-    - CPUS_COUNT=1 # NOTE-RT: We get 2 cores, but we'll actually be spawning more than 2 threads depending on what the actual builds'll be doing.
+    - CPUS_COUNT=4
     - TRAVIS_AUTHOR_EMAIL=travis@randytarampi.ca
     - TRAVIS_AUTHOR_NAME=Travis
     - SENTRY_ORG=randytarampi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - node_js: '11'
 env:
   global:
-    - CPUS_COUNT=2
+    - CPUS_COUNT=1 # NOTE-RT: We get 2 cores, but we'll actually be spawning more than 2 threads depending on what the actual builds'll be doing.
     - TRAVIS_AUTHOR_EMAIL=travis@randytarampi.ca
     - TRAVIS_AUTHOR_NAME=Travis
     - SENTRY_ORG=randytarampi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
   - export PRINTABLE_PUPPETEER_NO_SANDBOX=${CI:=true}
   - uname -a
   - lscpu
-  - sudo apt autoremove
   - npm install -g npm
 stages:
   - name: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-dist: xenial
+dist: trusty
 matrix:
   fast_finish: true
   allow_failures:
@@ -26,7 +26,6 @@ before_install:
   - uname -a
   - lscpu
   - sudo apt autoremove
-  - sudo apt-get remove libjpeg-turbo8-dev libjpeg9-dev+
   - npm install -g npm
 stages:
   - name: Test
@@ -261,7 +260,5 @@ addons:
       - japan*
       - fonts-wqy-microhei
       - ttf-wqy-microhei
-      - libgif-dev
-      - libpng16-dev
   hosts:
     - dynamodb-local

--- a/packages/pseudoimage/package.json
+++ b/packages/pseudoimage/package.json
@@ -66,7 +66,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@mcph/lwip": "github:randytarampi/lwip#me-release",
+    "@mcph/lwip": "github:randytarampi/lwip#me-release-2018-10-29",
     "commander": "^2.17.1",
     "mkdirp": "^0.5.1"
   }

--- a/packages/pseudoimage/test/integration/lib/pseudoimage.js
+++ b/packages/pseudoimage/test/integration/lib/pseudoimage.js
@@ -7,7 +7,7 @@ const Pseudoimage = require("../../../lib/pseudoimage");
 const {rmrf, openImage} = require("../../util");
 
 describe("pseudoimage", function () {
-    this.timeout(60000);
+    this.timeout(120000);
 
     const resourceDir = path.join(__dirname, "../../resources");
     const tmpDir = path.join(__dirname, "../../tmp");


### PR DESCRIPTION
It's just faster, everywhere (install, build, test and deploy). Any compile time improvements get lost in whatever extra slow I/O happens with the `xenial` builds.

Turns out the solution to #173 is just to close #173. 

Meat
---
- a4bd8046970803d80e47f8b9995dbcccb83d8386...c6254ff – Roll the build environment back to using `trusty`, since it seems like _on the whole_ builds are still a minute faster than the `xenial` ones.
