### PR TITLE
feat: Support galleries of `Photo`s. (#133)

### DIFF
--- a/packages/css/styles/post.scss
+++ b/packages/css/styles/post.scss
@@ -89,11 +89,15 @@
         margin-bottom: 0;
     }
 
-    &--photo {
+    &--photo, &--gallery {
         background-size: cover;
 
         .post-content, .post-metadata {
             background-size: cover;
+        }
+
+        img {
+            object-fit: cover;
         }
 
         & .col.post-content {

--- a/packages/js/src/lib/gallery.js
+++ b/packages/js/src/lib/gallery.js
@@ -1,0 +1,88 @@
+import {BlogPosting as SchemaBlogPosting, ImageObject as SchemaImageObject} from "@randy.tarampi/schema-dot-org-types";
+import {List} from "immutable";
+import Photo from "./photo";
+import Post, {PostClassGenerator} from "./post";
+import {sortPhotosByWidth} from "./util";
+
+export class Gallery extends PostClassGenerator({
+    photos: List()
+}) {
+    static get type() {
+        return "Gallery";
+    }
+
+    get sortedSizedPhotos() {
+        return this.photos.sort(sortPhotosByWidth);
+    }
+
+    get smallestPhoto() {
+        return this.sortedSizedPhotos.last();
+    }
+
+    get smallestImage() {
+        return this.smallestPhoto.smallestImage;
+    }
+
+    get largestPhoto() {
+        return this.sortedSizedPhotos.first();
+    }
+
+    get largestImage() {
+        return this.largestPhoto.largestImage;
+    }
+
+    static parsePropertiesFromJs(js) {
+        return {
+            ...Post.parsePropertiesFromJs(js),
+            photos: js.photos ? List(js.photos.map(photo => Photo.fromJS(photo))) : List()
+        };
+    }
+
+    static parsePropertiesFromJson(json) {
+        return {
+            ...Post.parsePropertiesFromJson(json),
+            photos: json.photos ? List(json.photos.map(photo => Photo.fromJSON(photo))) : List()
+        };
+    }
+
+    toSchema() {
+        const firstPhoto = this.photos.first();
+        const {photos, ...superSchema} = super.toSchema(); // eslint-disable-line no-unused-vars
+        const imagePostSchema = {
+            ...superSchema,
+            accessMode: "visual",
+            image: firstPhoto && firstPhoto.largestImage ? firstPhoto.largestImage.url : null
+        };
+
+        delete imagePostSchema.sharedContent;
+
+        return new SchemaBlogPosting({
+            ...imagePostSchema,
+            sharedContent: firstPhoto && firstPhoto.sortedSizedPhotos.size
+                ? new SchemaImageObject({
+                    ...imagePostSchema,
+                    uploadDate: superSchema.datePublished,
+                    height: `${firstPhoto.largestImage.height}px`,
+                    width: `${firstPhoto.largestImage.width}px`,
+                    caption: superSchema.articleBody,
+                    thumbnail: firstPhoto.smallestImage.url,
+                    contentUrl: imagePostSchema.image
+                })
+                : null
+        });
+    }
+
+    toRss(options = {}) {
+        const firstPhoto = this.photos.first();
+        return {
+            ...super.toRss(options),
+            enclosure: firstPhoto
+                ? {
+                    url: firstPhoto.largestImage.url
+                }
+                : null
+        };
+    }
+}
+
+export default Gallery;

--- a/packages/js/src/lib/index.js
+++ b/packages/js/src/lib/index.js
@@ -1,6 +1,7 @@
 export * from "./emoji";
 export * from "./util";
 
+export * from "./gallery";
 export * from "./organization";
 export * from "./place";
 export * from "./profile";

--- a/packages/js/src/lib/util/getEntityForType.js
+++ b/packages/js/src/lib/util/getEntityForType.js
@@ -1,8 +1,12 @@
+import Gallery from "../gallery";
 import Photo from "../photo";
 import Post from "../post";
 
 export const getEntityForType = type => {
     switch (type) {
+        case Gallery.type:
+            return Gallery;
+
         case Photo.type:
             return Photo;
 

--- a/packages/js/test/unit/src/lib/gallery.js
+++ b/packages/js/test/unit/src/lib/gallery.js
@@ -1,0 +1,328 @@
+import {expect} from "chai";
+import {List} from "immutable";
+import {DateTime} from "luxon";
+import Gallery from "../../../../src/lib/gallery";
+import Photo from "../../../../src/lib/photo";
+import {augmentUrlWithTrackingParams} from "../../../../src/lib/util";
+
+describe("Gallery", () => {
+    describe("constructor", () => {
+        it("should build a Gallery object", () => {
+            const galleryJs = {
+                id: "woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                width: -1,
+                height: -2,
+                photos: List([
+                    Photo.fromJS({
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 640,
+                        height: 480,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                    })
+                ]),
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }
+            };
+            const gallery = new Gallery(galleryJs);
+
+            expect(gallery.type).to.eql(Gallery.type);
+            expect(gallery.dateCreated).to.be.an.instanceOf(DateTime);
+            expect(gallery.datePublished).to.be.an.instanceOf(DateTime);
+            expect(gallery.photos).to.be.an.instanceOf(List);
+        });
+
+        it("returns an empty Gallery", function () {
+            const gallery = new Gallery();
+
+            expect(gallery).to.be.ok;
+            expect(gallery).to.be.instanceOf(Gallery);
+        });
+    });
+
+    describe(".fromJSON", () => {
+        it("should instantiate a Gallery object from some plain JS Object", () => {
+            const galleryJson = {
+                id: "woof",
+                type: "Woof",
+                source: "Woofdy",
+                dateCreated: null,
+                datePublished: DateTime.utc().toISO(),
+                width: -1,
+                height: -2,
+                photos: [
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 640,
+                        height: 480,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                    }
+                ],
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }
+            };
+
+            const galleryFromJson = Gallery.fromJSON(galleryJson);
+
+            expect(galleryFromJson).to.be.ok;
+            expect(galleryFromJson.id).to.eql(galleryJson.id);
+            expect(galleryFromJson.datePublished).to.be.instanceof(DateTime);
+            expect(galleryFromJson.photos).to.be.instanceof(List);
+            expect(galleryFromJson.photos.size).to.eql(galleryJson.photos.length);
+            galleryFromJson.photos.forEach(photo => {
+                expect(photo).to.be.ok;
+                expect(photo).to.be.instanceof(Photo);
+            });
+        });
+    });
+
+    describe(".fromJS", () => {
+        it("should instantiate a Gallery object from some plain JS Object", () => {
+            const galleryJson = {
+                id: "woof",
+                type: "Woof",
+                source: "Woofdy",
+                dateCreated: null,
+                datePublished: DateTime.utc(),
+                width: -1,
+                height: -2,
+                photos: [
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 640,
+                        height: 480,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                    },
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 800,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 800}]
+                    }
+                ],
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }
+            };
+
+            const galleryFromJs = Gallery.fromJS(galleryJson);
+
+            expect(galleryFromJs).to.be.ok;
+            expect(galleryFromJs.id).to.eql(galleryJson.id);
+            expect(galleryFromJs.datePublished).to.be.instanceof(DateTime);
+            expect(galleryFromJs.photos).to.be.instanceof(List);
+            expect(galleryFromJs.photos.size).to.eql(galleryJson.photos.length);
+            galleryFromJs.photos.forEach(photo => {
+                expect(photo).to.be.ok;
+                expect(photo).to.be.instanceof(Photo);
+            });
+        });
+    });
+
+    describe("#toSchema", function () {
+        it("returns expected Schema.org JSON", function () {
+            const galleryJson = {
+                id: "woof",
+                type: "Woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                width: -1,
+                height: -2,
+                photos: [
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 640,
+                        height: 480,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                    },
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 800,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 800}]
+                    }
+                ],
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }
+            };
+
+            const galleryFromJs = Gallery.fromJS(galleryJson);
+
+            const schemaJson = galleryFromJs.toSchema();
+            const {body, sourceUrl, type, photos, ...js} = galleryFromJs.toJS(); // eslint-disable-line no-unused-vars
+            const photoSchemaJson = {
+                ...js,
+                creator: galleryFromJs.creator.toSchema(),
+                author: galleryFromJs.creator.toSchema(),
+                publisher: galleryFromJs.creator.toSchema(),
+                dateCreated: galleryFromJs.dateCreated.toISO(),
+                dateModified: galleryFromJs.datePublished.toISO(),
+                datePublished: galleryFromJs.datePublished.toISO(),
+                accessMode: "visual",
+                articleBody: galleryFromJs.body,
+                articleSection: galleryFromJs.type,
+                headline: galleryFromJs.title,
+                name: galleryFromJs.title,
+                text: galleryFromJs.body,
+                mainEntityOfPage: galleryFromJs.sourceUrl,
+                image: galleryFromJs.largestImage.url
+            };
+
+            expect(schemaJson).to.eql({
+                ...photoSchemaJson,
+                sharedContent: {
+                    ...photoSchemaJson,
+                    uploadDate: photoSchemaJson.datePublished,
+                    height: `${galleryFromJs.largestImage.height}px`,
+                    width: `${galleryFromJs.largestImage.width}px`,
+                    caption: photoSchemaJson.articleBody,
+                    thumbnail: galleryFromJs.smallestImage.url,
+                    contentUrl: photoSchemaJson.image
+                }
+            });
+        });
+
+        it("returns some empty Schema.org JSON", function () {
+            const galleryFromJs = Gallery.fromJS();
+
+            const schemaJson = galleryFromJs.toSchema();
+            const {body, sourceUrl, type, photos, ...js} = galleryFromJs.toJS(); // eslint-disable-line no-unused-vars
+
+            expect(schemaJson).to.eql({
+                ...js,
+                accessMode: "visual",
+                articleSection: galleryFromJs.type,
+                articleBody: null,
+                headline: null,
+                name: null,
+                author: null,
+                publisher: null,
+                dateModified: null,
+                mainEntityOfPage: null,
+                sharedContent: null,
+                text: null,
+                image: null
+            });
+        });
+    });
+
+    describe("#toRss", function () {
+        it("returns expected `rss` item", function () {
+            const galleryJson = {
+                id: "woof",
+                type: "Woof",
+                source: "Woofdy",
+                dateCreated: DateTime.utc(),
+                datePublished: DateTime.utc(),
+                width: -1,
+                height: -2,
+                photos: [
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 640,
+                        height: 480,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                    },
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 800,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 800}]
+                    }
+                ],
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                }
+            };
+
+            const galleryFromJs = Gallery.fromJS(galleryJson);
+
+            const rssJson = galleryFromJs.toRss();
+
+            expect(rssJson).to.eql({
+                title: galleryFromJs.title,
+                description: galleryFromJs.body,
+                url: augmentUrlWithTrackingParams(galleryFromJs.sourceUrl),
+                guid: galleryFromJs.uid,
+                date: galleryFromJs.date.toJSDate(),
+                author: `${galleryFromJs.creator.url} (${galleryFromJs.creator.name})`,
+                enclosure: {
+                    url: galleryFromJs.largestImage.url
+                },
+                lat: null,
+                long: null
+            });
+        });
+
+        it("returns some empty `rss` item", function () {
+            const galleryFromJs = Gallery.fromJS();
+
+            const rssJson = galleryFromJs.toRss();
+
+            expect(rssJson).to.eql({
+                title: null,
+                description: null,
+                url: null,
+                guid: galleryFromJs.uid,
+                date: null,
+                author: null,
+                enclosure: null,
+                lat: null,
+                long: null
+            });
+        });
+    });
+});

--- a/packages/js/test/unit/src/lib/util.js
+++ b/packages/js/test/unit/src/lib/util.js
@@ -2,6 +2,7 @@ import {expect} from "chai";
 import {DateTime} from "luxon";
 import queryString from "query-string";
 import {Character} from "../../../../src/lib/emoji";
+import Gallery from "../../../../src/lib/gallery";
 import Photo from "../../../../src/lib/photo";
 import Post from "../../../../src/lib/post";
 import * as util from "../../../../src/lib/util";
@@ -79,6 +80,15 @@ describe("util", function () {
     });
 
     describe(".getEntityForType", function () {
+        it("gets `Gallery`s", function () {
+            const stubGallery = Gallery.fromJS({id: "grr", width: -2});
+
+            const GalleryConstructor = util.getEntityForType(stubGallery.type);
+
+            expect(stubGallery).to.be.instanceOf(GalleryConstructor);
+            expect(stubGallery).to.be.instanceOf(Gallery);
+        });
+
         it("gets `Photo`s", function () {
             const stubPhoto = Photo.fromJS({id: "grr", width: -2});
 

--- a/packages/jsx/src/lib/components/gallery.jsx
+++ b/packages/jsx/src/lib/components/gallery.jsx
@@ -1,0 +1,155 @@
+import {Gallery as GalleryEntity} from "@randy.tarampi/js";
+import SchemaJsonLdComponent from "@randy.tarampi/schema-dot-org-json-ld-components";
+import PropTypes from "prop-types";
+import React, {Fragment} from "react";
+import {Carousel, Col, Row} from "react-materialize";
+import ProgressiveImage from "react-progressive-image";
+import {WINDOW_LARGE_BREAKPOINT} from "../util";
+import {computeScaledHeight, PhotoComponent} from "./photo";
+import {
+    PostBodyAsArrayComponent,
+    PostBodyAsStringComponent,
+    PostDateCreatedComponent,
+    PostDatePublishedComponent,
+    PostTagsComponent,
+    PostTitleComponent
+} from "./post";
+
+export class GalleryComponent extends PhotoComponent {
+    get selected() {
+        return this.props.post.largestPhoto.getSizedPhotoForDisplay(this.targetWidth);
+    }
+
+    get scaledHeight() {
+        if (window.innerWidth >= WINDOW_LARGE_BREAKPOINT) {
+            return super.scaledHeight;
+        } else {
+            return this.props.post.photos.reduce((totalHeight, photo, index) => totalHeight += computeScaledHeight({
+                containerWidth: this.containerWidth,
+                photoWidth: photo.width,
+                photoHeight: photo.height,
+                postHtmlId: `${this.props.post.uid}-${index}`
+            }), 0);
+        }
+    }
+
+    render() {
+        const {post} = this.props;
+
+        const rowClassName = ["post post--gallery"];
+
+        return <Row
+            className={rowClassName.join(" ")}
+            id={post.uid}
+            style={{
+                backgroundImage: `linear-gradient(to top right,rgba(0,0,0,0.67),rgba(0,0,0,0.33)),url(${this.selected.url})`
+            }}
+        >
+            <SchemaJsonLdComponent markup={post.toSchema()}/>
+            {
+                window.innerWidth >= WINDOW_LARGE_BREAKPOINT
+                    ? <Fragment>
+                        <Col
+                            className="post-metadata hide-on-med-and-down"
+                            l={4}
+                        >
+                            <PostTitleComponent post={post} title={this.title}/>
+                            <PostBodyAsStringComponent post={post}/>
+                            <PostBodyAsArrayComponent post={post}/>
+                            <PostDatePublishedComponent post={post}/>
+                            <PostDateCreatedComponent post={post} label="Taken:"/>
+                            <PostTagsComponent post={post}/>
+                        </Col>
+                        <Col
+                            className="post-content hide-on-med-and-down"
+                            l={8}
+                            style={{
+                                height: this.scaledHeight
+                            }}
+                        >
+                            <Carousel options={{fullWidth: true, indicators: true, dist: 0}}
+                                      carouselId={`${post.uid}-carousel`}>
+                                {
+                                    post.photos.map((photo, index) => {
+                                        const placeholder = photo.getSizedPhotoForLoading(this.targetWidth);
+                                        const selected = photo.getSizedPhotoForDisplay(this.targetWidth);
+
+                                        // NOTE-RT: Needs to be a `div` otherwise `react-materialize` can't cling onto these carousel items
+                                        return <div key={`${post.uid}-${index}`}>
+                                            <ProgressiveImage
+                                                src={selected.url}
+                                                placeholder={placeholder.url}
+                                            >
+                                                {
+                                                    (source, isLoading) => <img
+                                                        className={isLoading ? "post--loading" : ""}
+                                                        src={source}
+                                                        style={{
+                                                            height: this.scaledHeight
+                                                        }}
+                                                    />
+                                                }
+                                            </ProgressiveImage>
+                                        </div>;
+                                    })
+                                }
+                            </Carousel>
+                        </Col>
+                    </Fragment>
+                    : post.photos.map((photo, index) => {
+                        const placeholder = photo.getSizedPhotoForLoading(this.targetWidth);
+                        const selected = photo.getSizedPhotoForDisplay(this.targetWidth);
+                        const title = `${this.title} (${index + 1}/${post.photos.size})`;
+
+                        return <Fragment key={`${post.uid}-${index}`}>
+                            <ProgressiveImage src={selected.url} placeholder={placeholder.url}>
+                                {
+                                    (source, isLoading) => <Col
+                                        id={`${post.uid}-${index + 1}`}
+                                        className={
+                                            ["post-metadata hide-on-large-only"]
+                                                .concat([isLoading ? "post--loading" : ""])
+                                                .join(" ")
+                                        }
+                                        s={12}
+                                        style={{
+                                            backgroundImage: `url(${source})`,
+                                            height: computeScaledHeight({
+                                                containerWidth: this.containerWidth,
+                                                photoWidth: selected.width,
+                                                photoHeight: selected.height,
+                                                postHtmlId: `${post.uid}-${index}`
+                                            })
+                                        }}
+                                    >
+                                        <div className="post-metadata hide-on-med-and-up">
+                                            <PostTitleComponent post={post} title={title}/>
+                                        </div>
+                                        <div className="post-metadata hide-on-small-only hide-on-large-only">
+                                            <PostTitleComponent post={post} title={title}/>
+                                            {
+                                                index === 0
+                                                    ? <Fragment>
+                                                        <PostDatePublishedComponent post={post}/>
+                                                        <PostDateCreatedComponent post={post} label="Taken:"/>
+                                                        <PostBodyAsStringComponent post={post}/>
+                                                        <PostBodyAsArrayComponent post={post}/>
+                                                    </Fragment>
+                                                    : null
+                                            }
+                                        </div>
+                                    </Col>
+                                }
+                            </ProgressiveImage>
+                        </Fragment>;
+                    })
+            }
+        </Row>;
+    }
+}
+
+GalleryComponent.propTypes = {
+    post: PropTypes.instanceOf(GalleryEntity).isRequired
+};
+
+export default GalleryComponent;

--- a/packages/jsx/src/lib/components/index.jsx
+++ b/packages/jsx/src/lib/components/index.jsx
@@ -4,6 +4,7 @@ export * from "./printable";
 export * from "./emoji";
 export * from "./error";
 export * from "./errorWrapper";
+export * from "./gallery";
 export * from "./loadingSpinner";
 export * from "./photo";
 export * from "./post";

--- a/packages/jsx/src/lib/containers/swipeableRoutes.jsx
+++ b/packages/jsx/src/lib/containers/swipeableRoutes.jsx
@@ -22,8 +22,7 @@ export const ConnectedSwipeableRoutes = withRouter(connect(
             location,
             index,
             resistance: true,
-            ignoreNativeScroll: true,
-            enableMouseEvents: true
+            ignoreNativeScroll: true
         };
     },
     {

--- a/packages/jsx/src/lib/data/posts.js
+++ b/packages/jsx/src/lib/data/posts.js
@@ -1,4 +1,4 @@
-import {castDatePropertyToDateTime, Photo, Post, sortPostsByDate} from "@randy.tarampi/js";
+import {castDatePropertyToDateTime, Gallery, Photo, Post, sortPostsByDate} from "@randy.tarampi/js";
 import {Map, Set} from "immutable";
 import {REHYDRATE} from "redux-persist/constants";
 import {createSelector} from "reselect";
@@ -54,7 +54,7 @@ export const createFilteredPostsSelector = (...filterOrSelectors) => filterOrSel
     ? createSelector(...filterOrSelectors)
     : createSelector(getPosts, ...filterOrSelectors);
 
-export const getPhotoPosts = createFilteredPostsSelector(posts => posts.filter(post => post instanceof Photo));
+export const getPhotoPosts = createFilteredPostsSelector(posts => posts.filter(post => post instanceof Photo || post instanceof Gallery));
 export const getWordPosts = createFilteredPostsSelector(posts => posts.filter(post => post instanceof Post));
 
 export const getPostsSortedByDate = createFilteredPostsSelector(posts => posts.sort(sortPostsByDate));

--- a/packages/jsx/src/lib/util/getComponentForType.js
+++ b/packages/jsx/src/lib/util/getComponentForType.js
@@ -1,9 +1,13 @@
-import {Photo, Post} from "@randy.tarampi/js";
+import {Gallery, Photo, Post} from "@randy.tarampi/js";
+import GalleryComponent from "../components/gallery";
 import PhotoComponent from "../components/photo";
 import PostComponent from "../components/post";
 
 export const getComponentForType = type => {
     switch (type) {
+        case Gallery.type:
+            return GalleryComponent;
+
         case Photo.type:
             return PhotoComponent;
 

--- a/packages/jsx/test/unit/src/lib/components/gallery.jsx
+++ b/packages/jsx/test/unit/src/lib/components/gallery.jsx
@@ -1,0 +1,222 @@
+import {Gallery as GalleryEntity} from "@randy.tarampi/js";
+import {expect} from "chai";
+import {shallow} from "enzyme";
+import React from "react";
+import {GalleryComponent} from "../../../../../src/lib/components/gallery";
+import {computeScaledHeight} from "../../../../../src/lib/components/photo";
+import {
+    PostBodyAsArrayComponent,
+    PostBodyAsStringComponent,
+    PostDateCreatedComponent,
+    PostDatePublishedComponent,
+    PostTagsComponent,
+    PostTitleComponent
+} from "../../../../../src/lib/components/post";
+import {WINDOW_LARGE_BREAKPOINT} from "../../../../../src/lib/util";
+
+
+describe("Gallery", function () {
+    let stubGallery;
+
+    beforeEach(function () {
+        stubGallery = GalleryEntity.fromJSON({
+            id: "woof",
+            type: "Woof",
+            source: "Woofdy",
+            dateCreated: new Date(1900, 0, 1).toISOString(),
+            datePublished: new Date(2500, 0, 1).toISOString(),
+            width: -1,
+            height: -2,
+            photos: [
+                {
+                    id: "woof://woof.woof/woof/woofto",
+                    width: 640,
+                    height: 480,
+                    sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                },
+                {
+                    id: "woof://woof.woof/woof/woofto?w=800",
+                    width: 800,
+                    sizedPhotos: [{url: "woof://woof.woof/woof/woofto?w=800", width: 800}]
+                }
+            ],
+            title: "Woof woof woof",
+            body: [
+                "ʕ•ᴥ•ʔ",
+                "ʕ•ᴥ•ʔﾉ゛",
+                "ʕ◠ᴥ◠ʔ"
+            ],
+            sourceUrl: "woof://woof.woof/woof",
+            creator: {
+                id: -1,
+                username: "ʕ•ᴥ•ʔ",
+                name: "ʕ•ᴥ•ʔ",
+                url: "woof://woof.woof/woof/woof/woof"
+            }
+        });
+    });
+
+    describe("GalleryComponent", function () {
+        it("renders (has Gallery)", function () {
+            stubGallery = GalleryEntity.fromJSON({
+                id: "woof",
+                type: "Woof",
+                source: "Woofdy",
+                dateCreated: null,
+                datePublished: new Date(2500, 0, 1).toISOString(),
+                width: -1,
+                height: -2,
+                photos: [
+                    {
+                        id: "woof://woof.woof/woof/woofto",
+                        width: 640,
+                        height: 480,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto", width: 640, height: 480}]
+                    },
+                    {
+                        id: "woof://woof.woof/woof/woofto?w=800",
+                        width: 800,
+                        sizedPhotos: [{url: "woof://woof.woof/woof/woofto?w=800", width: 800}]
+                    }
+                ],
+                title: "Woof woof woof",
+                body: [
+                    "ʕ•ᴥ•ʔ",
+                    "ʕ•ᴥ•ʔﾉ゛",
+                    "ʕ◠ᴥ◠ʔ"
+                ],
+                sourceUrl: "woof://woof.woof/woof",
+                creator: {
+                    id: -1,
+                    username: "ʕ•ᴥ•ʔ",
+                    name: "ʕ•ᴥ•ʔ",
+                    url: "woof://woof.woof/woof/woof/woof"
+                },
+                tags: [
+                    "woof",
+                    "meow",
+                    "grr"
+                ]
+            });
+
+            const stubProps = {
+                post: stubGallery,
+                containerHeight: 123,
+                containerWidth: 123
+            };
+            const rendered = shallow(<GalleryComponent {...stubProps}/>);
+
+            expect(rendered).to.be.ok;
+            expect(rendered).to.have.id(stubProps.post.uid);
+            expect(rendered).to.have.className("post--gallery");
+            expect(rendered).to.have.descendants(".post-metadata");
+            expect(rendered).to.have.descendants(".post-content");
+            expect(rendered).to.containMatchingElement(<PostTitleComponent post={stubGallery}
+                                                                           title={stubGallery.title}/>);
+            expect(rendered).to.containMatchingElement(<PostBodyAsStringComponent post={stubGallery}/>);
+            expect(rendered).to.containMatchingElement(<PostBodyAsArrayComponent post={stubGallery}/>);
+            expect(rendered).to.containMatchingElement(<PostDatePublishedComponent post={stubGallery}/>);
+            expect(rendered).to.containMatchingElement(<PostDateCreatedComponent post={stubGallery} label="Taken:"/>);
+            expect(rendered).to.containMatchingElement(<PostTagsComponent post={stubGallery}/>);
+        });
+
+        describe("#selected", function () {
+            const windowDpr = window.devicePixelRatio;
+
+            afterEach(function () {
+                window.devicePixelRatio = windowDpr;
+            });
+
+            it("returns the appropriate Gallery for no DPR", function () {
+                const stubProps = {
+                    post: stubGallery,
+                    containerHeight: 123,
+                    containerWidth: 123
+                };
+                const rendered = shallow(<GalleryComponent {...stubProps}/>);
+
+                expect(rendered).to.be.ok;
+                expect(rendered).to.have.id(stubProps.post.uid);
+                expect(rendered).to.have.className("post--gallery");
+
+                const component = rendered.instance();
+                expect(component).to.be.ok;
+                expect(component.selected).to.be.ok;
+                expect(component.selected).to.eql(stubGallery.largestPhoto.getSizedPhotoForLoading());
+            });
+
+            it("returns the appropriate Gallery for DPR", function () {
+                window.devicePixelRatio = 2;
+
+                const stubProps = {
+                    post: stubGallery,
+                    containerHeight: stubGallery.smallestPhoto.getSizedPhotoForLoading().width * 2,
+                    containerWidth: stubGallery.smallestPhoto.getSizedPhotoForLoading().height * 2
+                };
+                const rendered = shallow(<GalleryComponent {...stubProps}/>);
+
+                expect(rendered).to.be.ok;
+                expect(rendered).to.have.id(stubProps.post.uid);
+                expect(rendered).to.have.className("post--gallery");
+
+                const component = rendered.instance();
+                expect(component).to.be.ok;
+                expect(component.selected).to.be.ok;
+                expect(component.selected).to.eql(stubGallery.largestPhoto.sortedSizedPhotos.last());
+            });
+        });
+
+        describe("#scaledHeight", function () {
+            const windowInnerWidth = window.innerWidth;
+
+            afterEach(function () {
+                window.innerWidth = windowInnerWidth;
+            });
+
+            it("returns the scaledHeight for window.innerWidth < WINDOW_LARGE_BREAKPOINT", function () {
+                window.innerWidth = WINDOW_LARGE_BREAKPOINT / 2;
+
+                const stubProps = {
+                    post: stubGallery,
+                    containerHeight: 123,
+                    containerWidth: 123
+                };
+                const rendered = shallow(<GalleryComponent {...stubProps}/>);
+
+                expect(rendered).to.be.ok;
+                expect(rendered).to.have.id(stubProps.post.uid);
+                expect(rendered).to.have.className("post--gallery");
+
+                const component = rendered.instance();
+                expect(component).to.be.ok;
+                expect(component.scaledHeight).to.be.ok;
+                expect(component.scaledHeight).to.eql(
+                    computeScaledHeight({containerWidth: stubProps.containerWidth, photoWidth: 640, photoHeight: 480}),
+                    computeScaledHeight({containerWidth: stubProps.containerWidth, photoWidth: 800, photoHeight: 600})
+                );
+            });
+
+            it("returns the scaledHeight for window.innerWidth >= WINDOW_LARGE_BREAKPOINT", function () {
+                window.innerWidth = WINDOW_LARGE_BREAKPOINT * 2;
+
+                const stubProps = {
+                    post: stubGallery,
+                    containerHeight: 123,
+                    containerWidth: 123
+                };
+                const rendered = shallow(<GalleryComponent {...stubProps}/>);
+
+                expect(rendered).to.be.ok;
+                expect(rendered).to.have.id(stubProps.post.uid);
+                expect(rendered).to.have.className("post--gallery");
+
+                const component = rendered.instance();
+                expect(component).to.be.ok;
+                expect(component.scaledHeight).to.be.ok;
+                expect(component.scaledHeight).to.eql(
+                    computeScaledHeight({containerWidth: stubProps.containerWidth, photoWidth: 800, photoHeight: 600})
+                );
+            });
+        });
+    });
+});

--- a/packages/jsx/test/unit/src/lib/util/getComponentForType.js
+++ b/packages/jsx/test/unit/src/lib/util/getComponentForType.js
@@ -1,10 +1,19 @@
-import {Photo, Post} from "@randy.tarampi/js";
+import {Gallery, Photo, Post} from "@randy.tarampi/js";
 import {expect} from "chai";
+import GalleryComponent from "../../../../../src/lib/components/gallery";
 import PhotoComponent from "../../../../../src/lib/components/photo";
 import PostComponent from "../../../../../src/lib/components/post";
 import getComponentForType from "../../../../../src/lib/util/getComponentForType";
 
 describe("getComponentForType", function () {
+    it("gets `Gallery`s", function () {
+        const stubGallery = Gallery.fromJS({id: "grr", width: -2});
+
+        const GalleryConstructor = getComponentForType(stubGallery.type);
+
+        expect(GalleryConstructor).to.eql(GalleryComponent);
+    });
+
     it("gets `Photo`s", function () {
         const stubPhoto = Photo.fromJS({id: "grr", width: -2});
 

--- a/packages/service/src/db/schema/post.js
+++ b/packages/service/src/db/schema/post.js
@@ -1,4 +1,4 @@
-import {compositeKeySeparator, Photo, Post} from "@randy.tarampi/js";
+import {compositeKeySeparator, Gallery, Photo, Post} from "@randy.tarampi/js";
 import {Schema} from "dynamoose";
 
 const throughput = {read: 5, write: 5};
@@ -23,6 +23,7 @@ const post = new Schema({
         type: String,
         required: true,
         enum: [
+            Gallery.type,
             Photo.type,
             Post.type
         ],

--- a/packages/service/src/lib/util/index.js
+++ b/packages/service/src/lib/util/index.js
@@ -1,6 +1,6 @@
-import {Photo, Post} from "@randy.tarampi/js";
+import {Gallery, Photo, Post} from "@randy.tarampi/js";
 
-export const postTypes = [Post.type, Photo.type];
+export const postTypes = [Post.type, Photo.type, Gallery.type];
 
 export * from "./firstResolved";
 export * from "./xRayedAwsSdk";

--- a/packages/service/src/serverless/util/getPostsForParsedQuerystringParameters.js
+++ b/packages/service/src/serverless/util/getPostsForParsedQuerystringParameters.js
@@ -1,11 +1,19 @@
-import {sortPostsByDate} from "@randy.tarampi/js";
+import {Gallery, Photo, sortPostsByDate} from "@randy.tarampi/js";
 import _ from "lodash";
 import searchPosts from "../../lib/sources/searchPosts";
 import {postTypes} from "../../lib/util";
 import parseQueryStringParametersIntoSearchParams from "./parseQueryStringParametersIntoSearchParams";
 
 export const getPostsForParsedQuerystringParameters = ({type, ...queryParameters} = {}) => {
-    const postTypesToFetch = postTypes.filter(postType => type ? postType === type : true);
+    let postTypesToFetch = postTypes.filter(postType => type ? postType === type : true);
+
+    switch (type) {
+        case Photo.type:
+        case Gallery.type:
+            postTypesToFetch = [Gallery.type, Photo.type];
+            break;
+    }
+
     return Promise.all(
         postTypesToFetch
             .map(postType => searchPosts(parseQueryStringParametersIntoSearchParams({type: postType})(queryParameters)))
@@ -13,24 +21,27 @@ export const getPostsForParsedQuerystringParameters = ({type, ...queryParameters
         .then(results => {
             const flattenedPosts = _.flatten(results.map(result => result.posts));
             const uniquePosts = Object.values(flattenedPosts.reduce((keyedPosts, post) => {
-                keyedPosts[post.uid] = post;
+                if (post) {
+                    keyedPosts[post.uid] = post;
+                }
                 return keyedPosts;
             }, {}));
             const sortedPosts = uniquePosts.sort(sortPostsByDate);
             const paginatedPosts = sortedPosts.slice(0, queryParameters && queryParameters.perPage || 100);
+            const relevantResults = results.filter(result => result.total > 0);
 
             return {
                 posts: paginatedPosts,
                 total: {
-                    global: results.reduce((globalTotal, result) => globalTotal + result.total, 0),
+                    global: relevantResults.reduce((globalTotal, result) => globalTotal + result.total, 0),
                     ...(_.zipObject(postTypesToFetch, results.map(result => result.total)))
                 },
                 first: {
-                    global: _.sortBy(results, result => result && result.first && result.first.date)[0].first,
+                    global: _.sortBy(relevantResults, result => result && result.first && result.first.date)[0].first,
                     ...(_.zipObject(postTypesToFetch, results.map(result => result.first)))
                 },
                 last: {
-                    global: _.sortBy(results, result => result && result.last && result.last.date)[results.length - 1].last,
+                    global: _.sortBy(relevantResults, result => result && result.last && result.last.date)[relevantResults.length - 1].last,
                     ...(_.zipObject(postTypesToFetch, results.map(result => result.last)))
                 }
             };


### PR DESCRIPTION
Close #133 by hacking in support of `Gallery`s. 

Most of this is straighforward, but the change in 856c1ea is a bit big. In order to support the swipeable `Carousel` on large screens I needed to disable mouse events for `SwipeableRoutes`. Not a huge loss since it looks like I'm the only one that actually swipes between views on desktop (with a mouse).

Also, we're only supporting Tumblr at the moment since I don't actually have any Instagram galleries. 

Meat
---
- 18e6338  – Add a `Gallery` entity.
- 428d715  – Persist `Gallery` entities.
- 856c1ea  – Add a `Gallery` component.
